### PR TITLE
kserve: set storage initializer security context

### DIFF
--- a/applications/kserve/kserve/kustomization.yaml
+++ b/applications/kserve/kserve/kustomization.yaml
@@ -103,6 +103,25 @@ patches:
             seccompProfile:
               type: RuntimeDefault
 
+# Make the KServe storage initializer init container restricted-PSS compatible
+- patch: |
+    apiVersion: serving.kserve.io/v1alpha1
+    kind: ClusterStorageContainer
+    metadata:
+      name: default
+      namespace: kubeflow
+    spec:
+      container:
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          runAsNonRoot: true
+          runAsUser: 1000
+          seccompProfile:
+            type: RuntimeDefault
+
 # Delete ALL insecure LLMInferenceServiceConfig resources
 # IPC_LOCK, SYS_RAWIO, NET_RAW capabilities, runAsNonRoot: false
 # Ref: https://github.com/kubeflow/community-distribution/issues/3290


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## Summary of Changes

This PR adds a Kubeflow manifests-side Kustomize patch for `ClusterStorageContainer/default` so the KServe storage initializer container has a restricted-PSS compatible `securityContext`.

The patch sets:

- `allowPrivilegeEscalation: false`
- `capabilities.drop: [ALL]`
- `runAsNonRoot: true`
- `runAsUser: 1000`
- `seccompProfile.type: RuntimeDefault`

It does not edit generated upstream KServe bundle files and does not change test scripts.

## Dependencies

Related to kubeflow/manifests#3487. After this lands and is consumed by #3487, the temporary runtime `kubectl patch clusterstoragecontainer default` in #3487 can be removed.

## Related Issues

Related to kubeflow/manifests#3487.

## Contributor Checklist
  - [x] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
  - [ ] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).

Validation:

- `kustomize build applications/kserve/kserve`
- rendered `ClusterStorageContainer/default` securityContext assertion
- `git diff --check`
