### PR TITLE
dex: render the authcodes CustomResourceDefinition from templates

### DIFF
--- a/.github/workflows/helm-kustomize-comparison.yml
+++ b/.github/workflows/helm-kustomize-comparison.yml
@@ -25,6 +25,7 @@ on:
     - tests/helm_kustomize_compare.sh
     - tests/helm_kustomize_compare_all.sh
     - tests/test_dex_helm_rollout_checksums.py
+    - tests/test_dex_helm_crd_lifecycle.py
     - tests/test_istio_helm_chart.py
     - tests/test_dashboard_helm_chart.py
     - tests/test_generate_dashboard_helm_manifests.py
@@ -63,6 +64,8 @@ jobs:
       run: python tests/test_helm_kustomize_compare.py
     - name: Test Dex Helm behavior
       run: python tests/test_dex_helm_rollout_checksums.py
+    - name: Test Dex CustomResourceDefinition lifecycle
+      run: python tests/test_dex_helm_crd_lifecycle.py
     - name: Compare Dex Helm and Kustomize manifests
       env:
         VERBOSE: "true"

--- a/common/dex/helm/README.md
+++ b/common/dex/helm/README.md
@@ -33,9 +33,33 @@ The CI values contain the static user, OIDC client secret, and password hash
 needed to match the current Kustomize manifests. Chart defaults use placeholders
 and are not production credential guidance.
 
-The Dex `AuthCode` CRD is installed from the chart `crds/` directory. Helm
-installs CRDs before templates, but CRDs have special upgrade and deletion
-lifecycle behavior.
+## CustomResourceDefinition lifecycle
+
+Dex stores temporary OAuth authorization codes in Kubernetes through
+`authcodes.dex.coreos.com`. This chart renders that CustomResourceDefinition from
+`templates/crds.yaml`, carrying `helm.sh/resource-policy: keep`. It is controlled
+by `crds.enabled`, which defaults to `true`.
+
+**This deliberately deviates from Helm's published recommendation**, which is to
+place CustomResourceDefinitions in a chart `crds/` directory. Helm's own
+documentation states that there is *"no support at this time for upgrading or
+deleting CRDs using Helm"*
+([CRD best practices](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/)),
+so a resource in `crds/` keeps its first-install schema forever and is invisible
+to both `helm template` and `--dry-run`. Rendering from `templates/` means
+`helm upgrade` updates the schema, while `helm.sh/resource-policy: keep` stops
+`helm uninstall` from removing the definition and the `AuthCode` objects with it.
+
+Set `crds.enabled=false` when a cluster administrator manages
+CustomResourceDefinitions separately.
+
+`templates/crds.yaml` is hand-written rather than copied from upstream, because a
+copied file cannot carry the retention annotation. It is kept honest by
+`tests/test_dex_helm_crd_lifecycle.py`, which fails when it drifts from the
+upstream definition synchronized into `common/dex/base/upstream/crds.yaml`.
+`scripts/synchronize-dex-manifests.sh` runs the same check, so an upstream change
+that alters the definition fails the synchronization run rather than passing
+silently.
 
 ## Kustomize Mapping
 

--- a/common/dex/helm/templates/crds.yaml
+++ b/common/dex/helm/templates/crds.yaml
@@ -1,7 +1,10 @@
+{{- if .Values.crds.enabled }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: authcodes.dex.coreos.com
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   group: dex.coreos.com
   names:
@@ -18,3 +21,4 @@ spec:
       openAPIV3Schema:
         type: object
         x-kubernetes-preserve-unknown-fields: true
+{{- end }}

--- a/common/dex/helm/values.yaml
+++ b/common/dex/helm/values.yaml
@@ -1,5 +1,10 @@
 # Default values for the Kubeflow Dex chart.
 
+crds:
+  # -- Render the Dex authcodes CustomResourceDefinition. Disable when the
+  # cluster administrator manages CustomResourceDefinitions separately.
+  enabled: true
+
 rbac:
   # -- Render Dex RBAC resources.
   enabled: true

--- a/scripts/synchronize-dex-manifests.sh
+++ b/scripts/synchronize-dex-manifests.sh
@@ -26,11 +26,18 @@ sed -i "s|ghcr.io/dexidp/dex:v[0-9.]*|ghcr.io/dexidp/dex:${COMMIT}|g" \
   "$CHART_DIRECTORY/values.yaml"
 
 mkdir -p "$UPSTREAM_DIRECTORY"
-mkdir -p "$CHART_DIRECTORY/crds"
 cp \
   "$SOURCE_DIRECTORY/$REPOSITORY_DIRECTORY/scripts/manifests/crds/authcodes.yaml" \
   "$UPSTREAM_DIRECTORY/crds.yaml"
-cp "$UPSTREAM_DIRECTORY/crds.yaml" "$CHART_DIRECTORY/crds/authcodes.yaml"
+
+# The chart renders the CustomResourceDefinition from templates/crds.yaml rather
+# than from a crds directory, so that helm upgrade updates the schema. Helm never
+# upgrades a crds directory. The chart copy is therefore hand-written and cannot
+# be overwritten here; fail loudly when upstream changes it so it is updated
+# deliberately. tests/test_dex_helm_crd_lifecycle.py performs the same check in
+# continuous integration.
+python3 "${MANIFESTS_DIRECTORY}/tests/test_dex_helm_crd_lifecycle.py" \
+  ChartCustomResourceDefinitionMatchesUpstreamTest
 SOURCE_TEXT="\[.*\](https://github.com/${REPOSITORY_NAME}/releases/tag/v.*)"
 DESTINATION_TEXT="\[${COMMIT#v}\](https://github.com/${REPOSITORY_NAME}/releases/tag/${COMMIT})"
 update_readme "$MANIFESTS_DIRECTORY" "$SOURCE_TEXT" "$DESTINATION_TEXT"

--- a/tests/helm_kustomize_compare.py
+++ b/tests/helm_kustomize_compare.py
@@ -34,6 +34,9 @@ EXPECTED_HELM_CRD_RESOURCE_POLICIES = {
         "poddefaults.kubeflow.org",
         "profiles.kubeflow.org",
     },
+    "dex": {
+        "authcodes.dex.coreos.com",
+    },
 }
 
 

--- a/tests/test_dex_helm_crd_lifecycle.py
+++ b/tests/test_dex_helm_crd_lifecycle.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+ROOT_DIRECTORY = Path(__file__).resolve().parents[1]
+CHART_DIRECTORY = ROOT_DIRECTORY / "common" / "dex" / "helm"
+UPSTREAM_CUSTOM_RESOURCE_DEFINITION = (
+    ROOT_DIRECTORY / "common" / "dex" / "base" / "upstream" / "crds.yaml"
+)
+HELM_BINARY = os.environ.get("HELM_BINARY", "helm")
+CUSTOM_RESOURCE_DEFINITION_NAME = "authcodes.dex.coreos.com"
+RETENTION_ANNOTATION = "helm.sh/resource-policy"
+
+
+def load_custom_resource_definitions(documents):
+    return [
+        document
+        for document in documents
+        if document and document.get("kind") == "CustomResourceDefinition"
+    ]
+
+
+class ChartCustomResourceDefinitionMatchesUpstreamTest(unittest.TestCase):
+    """The chart copy is hand-written, so upstream drift must fail loudly."""
+
+    def test_chart_specification_matches_the_synchronized_upstream_file(self):
+        upstream = yaml.safe_load(UPSTREAM_CUSTOM_RESOURCE_DEFINITION.read_text())
+        chart_template = (CHART_DIRECTORY / "templates" / "crds.yaml").read_text()
+
+        body = "\n".join(
+            line for line in chart_template.splitlines() if not line.startswith("{{-")
+        )
+        chart = yaml.safe_load(body)
+
+        self.assertEqual(chart["metadata"]["name"], upstream["metadata"]["name"])
+        self.assertEqual(
+            chart["spec"],
+            upstream["spec"],
+            "common/dex/helm/templates/crds.yaml has drifted from the upstream "
+            "CustomResourceDefinition synchronized into "
+            "common/dex/base/upstream/crds.yaml. Update the chart template.",
+        )
+
+
+class DexCustomResourceDefinitionLifecycleTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.helm_plugins = tempfile.TemporaryDirectory()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.helm_plugins.cleanup()
+
+    def render_manifests(self, *values, include_custom_resource_definitions=False):
+        command = [
+            HELM_BINARY,
+            "template",
+            "dex",
+            str(CHART_DIRECTORY),
+            "--namespace",
+            "auth",
+        ]
+        if include_custom_resource_definitions:
+            command.append("--include-crds")
+        for value in values:
+            command.extend(["--set", value])
+
+        environment = os.environ.copy()
+        environment["HELM_PLUGINS"] = self.helm_plugins.name
+        result = subprocess.run(
+            command, check=True, capture_output=True, text=True, env=environment
+        )
+        return list(yaml.safe_load_all(result.stdout))
+
+    def test_custom_resource_definition_renders_without_the_include_flag(self):
+        """A crds directory needs --include-crds; templates/ does not.
+
+        Rendering with `helm template` and piping into `kubectl apply` is a
+        documented installation path, and it previously produced no
+        CustomResourceDefinition at all.
+        """
+        definitions = load_custom_resource_definitions(self.render_manifests())
+
+        self.assertEqual(len(definitions), 1)
+        self.assertEqual(
+            definitions[0]["metadata"]["name"], CUSTOM_RESOURCE_DEFINITION_NAME
+        )
+
+    def test_custom_resource_definition_is_retained_on_uninstall(self):
+        definitions = load_custom_resource_definitions(self.render_manifests())
+
+        annotations = definitions[0]["metadata"].get("annotations", {})
+        self.assertEqual(annotations.get(RETENTION_ANNOTATION), "keep")
+
+    def test_custom_resource_definition_can_be_disabled(self):
+        definitions = load_custom_resource_definitions(
+            self.render_manifests("crds.enabled=false")
+        )
+
+        self.assertEqual(definitions, [])
+
+    def test_chart_carries_no_crds_directory(self):
+        """Helm never upgrades or deletes anything in a chart's crds directory."""
+        self.assertFalse(
+            (CHART_DIRECTORY / "crds").exists(),
+            "common/dex/helm/crds must not exist; Helm freezes those resources at "
+            "first-install schema forever.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_helm_kustomize_compare.py
+++ b/tests/test_helm_kustomize_compare.py
@@ -300,6 +300,44 @@ class IstioManifestSelectionTest(unittest.TestCase):
         )
 
 
+def dex_custom_resource_definition(annotations=None):
+    metadata = {"name": "authcodes.dex.coreos.com"}
+    if annotations is not None:
+        metadata["annotations"] = annotations
+    return {
+        "apiVersion": "apiextensions.k8s.io/v1",
+        "kind": "CustomResourceDefinition",
+        "metadata": metadata,
+    }
+
+
+class DexCustomResourceDefinitionRetentionTest(unittest.TestCase):
+    """A crds directory carries no annotation, so this check catches a move back."""
+
+    def test_retained_definition_passes(self):
+        self.assertTrue(
+            helm_kustomize_compare.validate_helm_crd_resource_policies(
+                [dex_custom_resource_definition({"helm.sh/resource-policy": "keep"})],
+                "dex",
+            )
+        )
+
+    def test_definition_without_the_retention_annotation_fails(self):
+        self.assertFalse(
+            helm_kustomize_compare.validate_helm_crd_resource_policies(
+                [dex_custom_resource_definition()], "dex"
+            )
+        )
+
+    def test_component_without_an_entry_is_not_checked(self):
+        """No entry means the check is skipped, which is why this regression hid."""
+        self.assertTrue(
+            helm_kustomize_compare.validate_helm_crd_resource_policies(
+                [dex_custom_resource_definition()], "oauth2-proxy"
+            )
+        )
+
+
 class ComparisonWorkflowTest(unittest.TestCase):
     def test_dashboard_ignores_only_rollout_checksum_annotations(self):
         deployment = {


### PR DESCRIPTION
## The problem

Rendering the Dex chart with `helm template` produced **no CustomResourceDefinition at all**:

```console
$ kustomize build common/dex/overlays/oauth2-proxy | grep -c 'kind: CustomResourceDefinition'
1
$ helm template dex common/dex/helm --namespace auth --include-crds | grep -c 'kind: CustomResourceDefinition'
1
$ helm template dex common/dex/helm --namespace auth | grep -c 'kind: CustomResourceDefinition'
0
```

`authcodes.dex.coreos.com` lived in the chart's `crds/` directory, which Helm only installs with `--include-crds`. Rendering the chart and applying the output — a documented installation path — therefore installed a Dex that cannot store OAuth authorization codes.

Two further consequences of that directory:

- **The definition is never upgraded.** Helm's own documentation states there is *"no support at this time for upgrading or deleting CRDs using Helm"* ([CRD best practices](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/)), so it keeps its first-installed schema permanently.
- **It is invisible to `--dry-run`**, so custom resources cannot be validated against it.

## The change

The definition is now rendered from `common/dex/helm/templates/crds.yaml`, carrying `helm.sh/resource-policy: keep`, gated by `crds.enabled` (default `true`).

`helm upgrade` updates the schema; `helm uninstall` keeps the definition and the `AuthCode` objects. Set `crds.enabled=false` when an administrator manages CustomResourceDefinitions separately.

This deliberately deviates from Helm's published recommendation to use `crds/`, matching what `applications/dashboard/helm` already does for `profiles.kubeflow.org` and `poddefaults.kubeflow.org`. The chart README states the deviation and its reason.

### Why the template is hand-written

`scripts/synchronize-dex-manifests.sh` previously copied the upstream file into the chart. A copied file cannot carry the retention annotation, so the chart copy is now hand-written — and two independent checks fail if it drifts from the upstream definition synchronized into `common/dex/base/upstream/crds.yaml`:

- the synchronization script runs the drift check and aborts before committing;
- `tests/test_dex_helm_crd_lifecycle.py` runs the same check in continuous integration.

Verified by deliberately changing `singular: authcode` in the template, which fails with:

```
common/dex/helm/templates/crds.yaml has drifted from the upstream
CustomResourceDefinition synchronized into common/dex/base/upstream/crds.yaml.
```

### Making the fix stick

`validate_helm_crd_resource_policies` skips any component absent from `EXPECTED_HELM_CRD_RESOURCE_POLICIES`, which is why this regression passed the comparison unnoticed. Declaring `dex` turns it into enforcement — reverting the fix now fails the comparison:

```
Helm CRDs missing helm.sh/resource-policy=keep: authcodes.dex.coreos.com
```

## Verification

```console
$ python3 tests/test_dex_helm_crd_lifecycle.py
Ran 5 tests — OK
$ python3 -m unittest tests/test_helm_kustomize_compare.py
Ran 17 tests — OK
$ ./tests/helm_kustomize_compare_all.sh dex
SUCCESS: All scenarios passed for dex!
$ helm lint common/dex/helm --namespace auth
1 chart(s) linted, 0 chart(s) failed
```

Parity is unaffected: `helm.sh/*` annotations are normalized away on both sides, and the rendered resource set is unchanged.
