### PR TITLE
Update kubeflow/notebooks manifests to v2.0.0-beta.0

### DIFF
--- a/.github/workflows/workspaces_pipeline_run_test.yaml
+++ b/.github/workflows/workspaces_pipeline_run_test.yaml
@@ -18,6 +18,7 @@ on:
     - tests/pipelines_install.sh
     - tests/workspaces_install.sh
     - tests/workspaces_pipeline_run_test.sh
+    - tests/workspacekind.test.yaml
 
 permissions:
   contents: read

--- a/applications/workspaces/upstream/backend/base/deployment.yaml
+++ b/applications/workspaces/upstream/backend/base/deployment.yaml
@@ -36,9 +36,6 @@ spec:
         env:
         - name: PORT
           value: "4000"
-        # TODO: remove before GA
-        - name: DISABLE_AUTH
-          value: "false"
         resources:
           limits:
             cpu: 1

--- a/applications/workspaces/upstream/backend/base/kustomization.yaml
+++ b/applications/workspaces/upstream/backend/base/kustomization.yaml
@@ -18,4 +18,4 @@ labels:
 images:
 - name: workspaces-backend
   newName: ghcr.io/kubeflow/notebooks/workspaces-backend
-  newTag: v2.0.0-alpha.3
+  newTag: v2.0.0-beta.0

--- a/applications/workspaces/upstream/backend/base/rbac.yaml
+++ b/applications/workspaces/upstream/backend/base/rbac.yaml
@@ -47,6 +47,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods/log
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumeclaims
   verbs:
   - get
@@ -70,6 +76,13 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - metrics.k8s.io
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
 - apiGroups:
   - authorization.k8s.io
   resources:

--- a/applications/workspaces/upstream/backend/components/common/kustomization.yaml
+++ b/applications/workspaces/upstream/backend/components/common/kustomization.yaml
@@ -4,6 +4,9 @@ kind: Component
 labels:
 - includeSelectors: true
   pairs:
-    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: workspaces-backend
     app.kubernetes.io/part-of: kubeflow-workspaces
+- includeSelectors: false
+  includeTemplates: true
+  pairs:
+    app.kubernetes.io/managed-by: kustomize

--- a/applications/workspaces/upstream/backend/components/istio/authorization-policy.yaml
+++ b/applications/workspaces/upstream/backend/components/istio/authorization-policy.yaml
@@ -8,7 +8,6 @@ spec:
     matchLabels:
       app: workspaces-backend
       app.kubernetes.io/component: api
-      app.kubernetes.io/managed-by: kustomize
       app.kubernetes.io/name: workspaces-backend
       app.kubernetes.io/part-of: kubeflow-workspaces
   rules:

--- a/applications/workspaces/upstream/controller/base/crd/kubeflow.org_workspacekinds.yaml
+++ b/applications/workspaces/upstream/controller/base/crd/kubeflow.org_workspacekinds.yaml
@@ -54,10 +54,522 @@ spec:
           spec:
             description: WorkspaceKindSpec defines the desired state of WorkspaceKind
             properties:
+              activityRules:
+                description: |-
+                  activityRules defines the policies for handling inactivity in Workspaces of this WorkspaceKind (MUTABLE).
+                  Rules are evaluated sequentially from top to bottom (first-match-wins semantics) independently for each
+                  configured effect type (e.g., pauseWorkspace). A rule with a nil or empty 'match' is treated as a catch-all
+                  rule; at most one catch-all rule is allowed per effect type, and it must be the last rule in the list.
+                items:
+                  description: ActivityRule defines a policy for handling inactivity
+                    in a Workspace
+                  properties:
+                    config:
+                      description: the configuration for this rule
+                      properties:
+                        minRunningSeconds:
+                          default: 0
+                          description: the minimum duration in seconds a Workspace
+                            must be running before it can be paused due to inactivity
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        secondsSinceActive:
+                          description: |-
+                            the number of seconds of inactivity before a Workspace is eligible for this rule's effect
+                             - the minimum value is 16 (`secondsSinceActive` > 15) to prevent thrashing and pausing
+                               workspaces prematurely during startup or transient connection drops
+                          format: int32
+                          minimum: 16
+                          type: integer
+                      required:
+                      - secondsSinceActive
+                      type: object
+                    effect:
+                      description: the action to take when the rule matches and its
+                        conditions are met
+                      properties:
+                        pauseWorkspace:
+                          description: |-
+                            determines if the Workspace should be paused
+                             - the webhook rejects rules with `pauseWorkspace: true`
+                               when no `activityProbe` is configured
+                          type: boolean
+                      type: object
+                      x-kubernetes-validations:
+                      - message: must specify at least one effect
+                        rule: has(self.pauseWorkspace)
+                    match:
+                      description: the conditions under which this rule applies
+                      properties:
+                        matchNamespace:
+                          description: filters Workspaces by namespace labels
+                          properties:
+                            selector:
+                              description: the standard Kubernetes label selector
+                                to match namespace labels
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          required:
+                          - selector
+                          type: object
+                        matchPodConfig:
+                          description: filters Workspaces by the PodConfig option
+                            they are using
+                          properties:
+                            selector:
+                              description: the standard Kubernetes label selector
+                                to match podConfig labels
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          required:
+                          - selector
+                          type: object
+                      type: object
+                  required:
+                  - config
+                  - effect
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              filterRules:
+                description: |-
+                  filterRules are admin-defined rules used by downstream consumers (the backend API server)
+                  to dynamically filter which WorkspaceKinds, imageConfig values, and podConfig values are
+                  visible or allowed in a given context. (MUTABLE)
+                  The controller does NOT evaluate or act on these rules, it only persists and validates them.
+                items:
+                  description: |-
+                    FilterRule is a single admin-defined rule which applies an effect to matched
+                    items (WorkspaceKinds, imageConfig values, or podConfig values) when all of
+                    its match conditions are satisfied.
+                  properties:
+                    effect:
+                      description: the effect to apply to matched items when all `match`
+                        conditions are satisfied
+                      properties:
+                        api:
+                          description: server-enforced behavior evaluated by the backend
+                            API server
+                          properties:
+                            deny:
+                              description: return the matched item but reject any
+                                workspace create/update which selects it
+                              type: boolean
+                            denyMessage:
+                              description: a message explaining why the matched item
+                                is denied
+                              properties:
+                                text:
+                                  description: the text of the message to show when
+                                    the item is denied
+                                  maxLength: 1024
+                                  minLength: 2
+                                  type: string
+                              required:
+                              - text
+                              type: object
+                            hide:
+                              description: omit the matched item from the API response
+                                entirely
+                              type: boolean
+                          type: object
+                          x-kubernetes-validations:
+                          - message: '''denyMessage'' may only be set when ''deny''
+                              is true'
+                            rule: '!has(self.denyMessage) || (has(self.deny) && self.deny)'
+                        ui:
+                          description: rendering hints for the frontend (the item
+                            is still returned by the API)
+                          properties:
+                            hide:
+                              description: suggest the UI hide the matched item
+                              type: boolean
+                          required:
+                          - hide
+                          type: object
+                      type: object
+                      x-kubernetes-validations:
+                      - message: must specify at least one of 'ui' or 'api'
+                        rule: has(self.ui) || has(self.api)
+                    match:
+                      description: the conditions which must ALL be satisfied for
+                        the rule to apply
+                      items:
+                        description: FilterRuleMatch defines a single match condition
+                          for a filter rule
+                        properties:
+                          matchImageConfig:
+                            description: match against the `spawner.labels` of an
+                              imageConfig value
+                            properties:
+                              selector:
+                                description: a standard Kubernetes label selector
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            required:
+                            - selector
+                            type: object
+                          matchNamespace:
+                            description: match against the labels of the namespace
+                              the workspace would be created in
+                            properties:
+                              selector:
+                                description: a standard Kubernetes label selector
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            required:
+                            - selector
+                            type: object
+                          matchPodConfig:
+                            description: match against the `spawner.labels` of a podConfig
+                              value
+                            properties:
+                              selector:
+                                description: a standard Kubernetes label selector
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            required:
+                            - selector
+                            type: object
+                        type: object
+                        x-kubernetes-validations:
+                        - message: must specify exactly one of 'matchNamespace', 'matchImageConfig',
+                            or 'matchPodConfig'
+                          rule: '(has(self.matchNamespace) ? 1 : 0) + (has(self.matchImageConfig)
+                            ? 1 : 0) + (has(self.matchPodConfig) ? 1 : 0) == 1'
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    scope:
+                      description: the type of resource whose visibility this rule
+                        controls
+                      enum:
+                      - WORKSPACE_KIND
+                      - POD_CONFIG
+                      - IMAGE_CONFIG
+                      type: string
+                  required:
+                  - effect
+                  - match
+                  - scope
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
               podTemplate:
                 description: podTemplate is the PodTemplate used to spawn Pods to
                   run Workspaces of this WorkspaceKind
                 properties:
+                  activityProbe:
+                    description: activityProbe configs to determine Workspace activity
+                      (MUTABLE)
+                    properties:
+                      jupyter:
+                        description: a Jupyter-specific API probe
+                        properties:
+                          lastActivity:
+                            description: if the Jupyter-specific probe is enabled
+                            example: true
+                            type: boolean
+                          portId:
+                            description: the port to probe, referencing a port defined
+                              in spec.podTemplate.ports
+                            maxLength: 32
+                            minLength: 1
+                            pattern: ^[a-z0-9]([a-z0-9_-]*[a-z0-9])?$
+                            type: string
+                        required:
+                        - lastActivity
+                        - portId
+                        type: object
+                        x-kubernetes-validations:
+                        - message: '''lastActivity'' must be true'
+                          rule: has(self.lastActivity) && self.lastActivity
+                      minProbeIntervalSeconds:
+                        default: 300
+                        description: |-
+                          the minimum duration in seconds that must elapse between two consecutive probes.
+                          - Acts as a rate-limiter for failed probes: if a probe fails, the controller waits at least this long before retrying (requeuing after minProbeInterval).
+                          - Also acts as a guard: if a reconcile triggers early, the probe is skipped until this interval has elapsed since the last probe.
+                        format: int32
+                        maximum: 31536000
+                        minimum: 1
+                        type: integer
+                      podExec:
+                        description: a script-based probe executed in the Pod
+                        properties:
+                          script:
+                            description: |-
+                              script is the script to run inside the Pod to determine if the Workspace is active.
+                              The script must meet the following requirements:
+                               - The Pod's main container MUST provide a POSIX shell at "/bin/sh" and the "cat", "chmod",
+                                 and "rm" utilities, which the controller uses to stage and execute the script. Minimal
+                                 or distroless images without these will cause the probe to fail (and never pause).
+                               - It must start with a shebang (e.g., "#!/usr/bin/env bash" or "#!/usr/bin/env python").
+                               - It must exit with a 0 status code. A non-zero exit code is treated as a probe failure (Workspaces with failing probes are not paused).
+                               - It should be idempotent and without side effects since it can be run multiple times.
+                               - If the script wants to report an INACTIVE state, it MUST write a JSON object to the file path
+                                 supplied in the OUTPUT_JSON_PATH environment variable.
+                               - When has_activity is not provided and last_activity is provided, last_activity is the authoritative source of truth:
+                                 a successful probe unconditionally overwrites `status.activity.lastActivity` with the reported
+                                 timestamp (the controller does not validate monotonicity or clamp to wall-clock time).
+                               - The JSON fields `has_activity` (boolean) and `last_activity` (ISO 8601 string) are mutually exclusive;
+                                 users should specify one or the other, not both. If both fields are present, `has_activity` takes
+                                 precedence and `last_activity` is totally ignored (the probe does not fail).
+                                 The fields are evaluated to update the Workspace status field `status.activity.lastActivity` as follows:
+                                   - If `has_activity` is explicitly set to `true` (or if the JSON file is empty/omitted): The Workspace is treated as active, and `status.activity.lastActivity` is updated to the probe completion time (ignoring `last_activity`).
+                                   - If `has_activity` is explicitly set to `false`: The Workspace is treated as inactive, and the existing `status.activity.lastActivity` timestamp is preserved (unchanged, ignoring `last_activity`).
+                                   - If `last_activity` (ISO 8601 string) is provided (and `has_activity` is omitted): The Workspace is treated as inactive, and `status.activity.lastActivity` is updated to the `last_activity` timestamp.
+                            maxLength: 2048
+                            minLength: 1
+                            type: string
+                          timeoutSeconds:
+                            default: 60
+                            description: the maximum number of seconds the probe is
+                              allowed to run
+                            format: int32
+                            minimum: 1
+                            type: integer
+                        required:
+                        - script
+                        type: object
+                      probeIntervalSeconds:
+                        default: 3600
+                        description: |-
+                          the desired interval in seconds between successful probes.
+                           - If a probe succeeds, the controller schedules the next probe after this duration (requeuing after probeInterval).
+                           - Determines the freshness of workspace activity status used by activity rules.
+                           - ACTIVITY TIMING CAVEAT: a Workspace is only paused immediately after a fresh probe confirms it is still
+                             inactive (a Workspace is never paused based on stale activity data, so an actively-used Workspace whose
+                             user resumed activity between probes is not paused). Consequently, activity rules are only evaluated at probe time,
+                             so a Workspace may keep running for up to ~probeIntervalSeconds after it first becomes eligible
+                             (lastActivity + secondsSinceActive) before it is actually paused. Lower this value for tighter timing,
+                             at the cost of more frequent probing.
+                        format: int32
+                        maximum: 31536000
+                        minimum: 1
+                        type: integer
+                    type: object
+                    x-kubernetes-validations:
+                    - message: must specify exactly one of 'podExec' or 'jupyter'
+                      rule: '!(has(self.podExec) && has(self.jupyter)) && (has(self.podExec)
+                        || has(self.jupyter))'
+                    - message: minProbeIntervalSeconds must be less than or equal
+                        to probeIntervalSeconds
+                      rule: self.minProbeIntervalSeconds <= self.probeIntervalSeconds
                   containerSecurityContext:
                     description: container security context for Workspace Pods (MUTABLE)
                     properties:
@@ -249,68 +761,6 @@ spec:
                               PodSecurityContext, the value specified in SecurityContext takes precedence.
                             type: string
                         type: object
-                    type: object
-                  culling:
-                    description: culling configs for pausing inactive Workspaces (MUTABLE)
-                    properties:
-                      activityProbe:
-                        description: the probe used to determine if the Workspace
-                          is active
-                        properties:
-                          exec:
-                            description: |-
-                              a shell command probe
-                               - if the Workspace had activity in the last 60 seconds this command
-                                 should return status 0, otherwise it should return status 1
-                            properties:
-                              command:
-                                description: the command to run
-                                example:
-                                - bash
-                                - -c
-                                - exit 0
-                                items:
-                                  type: string
-                                minItems: 1
-                                type: array
-                            required:
-                            - command
-                            type: object
-                          jupyter:
-                            description: |-
-                              a Jupyter-specific probe
-                               - will poll the `/api/status` endpoint of the Jupyter API, and use the `last_activity` field
-                               - note, users need to be careful that their other probes don't trigger a "last_activity" update
-                                 e.g. they should only check the health of Jupyter using the `/api/status` endpoint
-                            properties:
-                              lastActivity:
-                                description: if the Jupyter-specific probe is enabled
-                                example: true
-                                type: boolean
-                            required:
-                            - lastActivity
-                            type: object
-                            x-kubernetes-validations:
-                            - message: '''lastActivity'' must be true'
-                              rule: has(self.lastActivity) && self.lastActivity
-                        type: object
-                        x-kubernetes-validations:
-                        - message: must specify exactly one of 'exec' or 'jupyter'
-                          rule: '!(has(self.exec) && has(self.jupyter)) && (has(self.exec)
-                            || has(self.jupyter))'
-                      enabled:
-                        default: true
-                        description: if the culling feature is enabled
-                        type: boolean
-                      maxInactiveSeconds:
-                        default: 86400
-                        description: the maximum number of seconds a Workspace can
-                          be inactive
-                        format: int32
-                        minimum: 60
-                        type: integer
-                    required:
-                    - activityProbe
                     type: object
                   extraEnv:
                     description: |-
@@ -4439,25 +4889,48 @@ spec:
                         type: object
                     type: object
                   serviceAccount:
-                    description: service account configs for Workspace Pods
+                    description: |-
+                      service account configs for Workspace Pods
+                       - each Workspace runs as its own ServiceAccount, which is created and owned by
+                         the controller and named "ws-{WORKSPACE_NAME}"
+                       - the resolved name is reported in the Workspace `status.podTemplatePod.serviceAccountName`
                     properties:
-                      name:
+                      clusterRoles:
                         description: |-
-                          the name of the ServiceAccount (NOT MUTABLE)
-                           - this Service Account MUST already exist in the Namespace
-                             of the Workspace, the controller will NOT create it
-                           - we will not show this WorkspaceKind in the Spawner UI
-                             if the SA does not exist in the Namespace
-                        example: default-editor
-                        maxLength: 253
-                        minLength: 1
-                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                        type: string
-                        x-kubernetes-validations:
-                        - message: ServiceAccount 'name' is immutable
-                          rule: self == oldSelf
-                    required:
-                    - name
+                          the ClusterRoles to grant to the ServiceAccount of each Workspace (MUTABLE)
+                           - each entry becomes a namespaced RoleBinding, NOT a ClusterRoleBinding, so the
+                             permissions only apply inside the Namespace of the Workspace
+                           - removing an entry deletes the corresponding RoleBinding
+                           - the referenced ClusterRoles do not have to exist, a RoleBinding to a missing
+                             ClusterRole simply grants nothing until that ClusterRole is created
+                           - changes take effect immediately, Workspaces do NOT need to be restarted
+                        example:
+                        - name: kubeflow-edit
+                        items:
+                          description: |-
+                            WorkspaceKindClusterRole identifies a ClusterRole to bind to a Workspace's ServiceAccount
+                            via a namespaced RoleBinding.
+                          properties:
+                            name:
+                              description: |-
+                                the name of the ClusterRole to bind to the Workspace ServiceAccount
+                                 - note, ClusterRole names are path segment names, so unlike most Kubernetes
+                                   resource names they may contain uppercase letters and ":" (for example,
+                                   the aggregated "system:aggregate-to-view" ClusterRole)
+                                 - the pattern is the regex form of Kubernetes `IsValidPathSegmentName`:
+                                   the name must not be "." or "..", and must not contain "/" or "%"
+                              example: kubeflow-edit
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^([^./%][^/%]*|\.[^./%][^/%]*|\.[^/%][^/%]+)$
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                     type: object
                   volumeMounts:
                     description: volume mount paths
@@ -4478,7 +4951,6 @@ spec:
                 required:
                 - options
                 - ports
-                - serviceAccount
                 - volumeMounts
                 type: object
               spawner:

--- a/applications/workspaces/upstream/controller/base/crd/kubeflow.org_workspaces.yaml
+++ b/applications/workspaces/upstream/controller/base/crd/kubeflow.org_workspaces.yaml
@@ -46,6 +46,13 @@ spec:
           spec:
             description: WorkspaceSpec defines the desired state of Workspace
             properties:
+              displayName:
+                description: an optional human-readable name for the Workspace, displayed
+                  in the UI instead of metadata.name
+                example: My Workspace
+                maxLength: 128
+                minLength: 1
+                type: string
               kind:
                 description: the WorkspaceKind to use
                 example: jupyterlab
@@ -207,32 +214,102 @@ spec:
             properties:
               activity:
                 description: activity information for the Workspace, used to determine
-                  when to cull
+                  activity rule actions
                 properties:
                   lastActivity:
                     default: 0
-                    description: the last time activity was observed on the Workspace
-                      (UNIX epoch)
-                    example: 1704067200
+                    description: |-
+                      the last time activity was observed on the Workspace (UNIX epoch in milliseconds)
+                       - this is the value returned by the activity probe, not the time the probe was run
+                       - the activity probe is authoritative: on success, the probe result unconditionally
+                         overwrites this timestamp (the controller does not validate monotonicity or clamp to wall-clock time)
+                       - not updated when a probe fails
+                    example: 1704067200000
                     format: int64
                     type: integer
+                  lastProbe:
+                    description: probe result tracking
+                    properties:
+                      endTime:
+                        description: the time the probe was completed (UNIX epoch
+                          in milliseconds)
+                        example: 1710435305000
+                        format: int64
+                        type: integer
+                      message:
+                        default: ""
+                        description: |-
+                          a human-readable message about the probe result
+                           - WARNING: this field is NOT FOR MACHINE USE, subject to change without notice
+                        example: Jupyter probe succeeded
+                        type: string
+                      result:
+                        description: the result of the last probe execution
+                        enum:
+                        - Success
+                        - Failure
+                        - Timeout
+                        type: string
+                      startTime:
+                        description: the time the probe was started (UNIX epoch in
+                          milliseconds)
+                        example: 1710435303000
+                        format: int64
+                        type: integer
+                    required:
+                    - endTime
+                    - message
+                    - result
+                    - startTime
+                    type: object
                   lastUpdate:
                     default: 0
-                    description: the last time we checked for activity on the Workspace
-                      (UNIX epoch)
-                    example: 1704067200
+                    description: |-
+                      the end time of the last successful probe (UNIX epoch in milliseconds)
+                       - not updated when a probe fails
+                       - used to determine when the next probe should run
+                    example: 1704067200000
                     format: int64
                     type: integer
+                  rules:
+                    description: rule evaluation state
+                    properties:
+                      pauseWorkspace:
+                        description: rule evaluation state for the pauseWorkspace
+                          effect
+                        properties:
+                          eligibleAfter:
+                            default: 0
+                            description: |-
+                              the time after which if the rule is evaluated the Workspace would be paused (UNIX epoch in milliseconds)
+                               - set to 0 when lastActivity is unknown (<= 0), indicating eligibility cannot be computed / not applicable
+                               - the controller will not pause a Workspace when eligibleAfter is 0
+                            example: 1707667200000
+                            format: int64
+                            type: integer
+                        required:
+                        - eligibleAfter
+                        type: object
+                    type: object
                 required:
                 - lastActivity
                 - lastUpdate
                 type: object
+              lastRunningTime:
+                default: 0
+                description: |-
+                  the last time the Workspace entered a Running state (UNIX epoch in milliseconds)
+                   - used to compute running duration for `minRunningSeconds` activity guard
+                   - set to 0 when the Workspace has never been in a Running state
+                example: 1704060000000
+                format: int64
+                type: integer
               pauseTime:
                 default: 0
                 description: |-
-                  the time when the Workspace was paused (UNIX epoch)
+                  the time when the Workspace was paused (UNIX epoch in milliseconds)
                    - set to 0 when the Workspace is NOT paused
-                example: 1704067200
+                example: 1704067200000
                 format: int64
                 type: integer
               pendingRestart:
@@ -344,6 +421,14 @@ spec:
                   nodeName:
                     description: the name of the node on which the Pod is scheduled
                     type: string
+                  serviceAccountName:
+                    description: |-
+                      the name of the ServiceAccount that the Pod runs as
+                       - this ServiceAccount is created and owned by the Workspace, and is stable for its lifetime
+                       - it is reported here so that Roles, RoleBindings, and Istio AuthorizationPolicies
+                         which reference the ServiceAccount do not have to recompute its name
+                    example: ws-my-workspace
+                    type: string
                 required:
                 - name
                 - nodeName
@@ -367,6 +452,7 @@ spec:
                 type: string
             required:
             - activity
+            - lastRunningTime
             - pauseTime
             - pendingRestart
             - podTemplateOptions

--- a/applications/workspaces/upstream/controller/base/manager/kustomization.yaml
+++ b/applications/workspaces/upstream/controller/base/manager/kustomization.yaml
@@ -19,4 +19,4 @@ labels:
 images:
 - name: workspaces-controller
   newName: ghcr.io/kubeflow/notebooks/workspaces-controller
-  newTag: v2.0.0-alpha.3
+  newTag: v2.0.0-beta.0

--- a/applications/workspaces/upstream/controller/base/manager/role.yaml
+++ b/applications/workspaces/upstream/controller/base/manager/role.yaml
@@ -9,6 +9,7 @@ rules:
   resources:
   - configmaps
   - events
+  - namespaces
   - pods
   verbs:
   - get
@@ -17,6 +18,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods/exec
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
   - services
   verbs:
   - create
@@ -71,6 +79,24 @@ rules:
   - networking.istio.io
   resources:
   - virtualservices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  verbs:
+  - bind
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
   verbs:
   - create
   - delete

--- a/applications/workspaces/upstream/controller/base/manager/user_cluster_roles.yaml
+++ b/applications/workspaces/upstream/controller/base/manager/user_cluster_roles.yaml
@@ -1,7 +1,7 @@
 ##
 ## WARNING: Kubernetes will REMOVE any existing content of `rules` when using `aggregationRule`. 
 ##          So, we define both the `aggregate-to-kubeflow-workspaces-edit` and `kubeflow-workspaces-edit` 
-##          even though only `kubeflow-workspaces-edit` is indented to be used in a binding.
+##          even though only `kubeflow-workspaces-edit` is intended to be used in a binding.
 ##          https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles
 ##
 apiVersion: rbac.authorization.k8s.io/v1
@@ -41,6 +41,28 @@ aggregationRule:
   - matchLabels:
       rbac.authorization.kubeflow.org/aggregate-to-kubeflow-workspaces-view: "true"
 rules: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aggregate-to-kubeflow-workspaces-admin
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-workspaces-admin: "true"
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - workspacekinds
+  - workspacekinds/status
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/applications/workspaces/upstream/controller/components/common/kustomization.yaml
+++ b/applications/workspaces/upstream/controller/components/common/kustomization.yaml
@@ -4,6 +4,9 @@ kind: Component
 labels:
 - includeSelectors: true
   pairs:
-    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: workspaces-controller
     app.kubernetes.io/part-of: kubeflow-workspaces
+- includeSelectors: false
+  includeTemplates: true
+  pairs:
+    app.kubernetes.io/managed-by: kustomize

--- a/applications/workspaces/upstream/controller/components/prometheus/kustomization.yaml
+++ b/applications/workspaces/upstream/controller/components/prometheus/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Component
 
 resources:
 - monitor.yaml
+- network-policy.yaml
 - service.yaml
 
 patches:

--- a/applications/workspaces/upstream/controller/components/prometheus/monitor.yaml
+++ b/applications/workspaces/upstream/controller/components/prometheus/monitor.yaml
@@ -13,6 +13,5 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: metrics
-      app.kubernetes.io/managed-by: kustomize
       app.kubernetes.io/name: workspaces-controller
       app.kubernetes.io/part-of: kubeflow-workspaces

--- a/applications/workspaces/upstream/controller/components/prometheus/network-policy.yaml
+++ b/applications/workspaces/upstream/controller/components/prometheus/network-policy.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-prometheus-scrape
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: controller-manager
+  policyTypes:
+  - Ingress
+  ingress:
+  - ports:
+    - port: metrics
+      protocol: TCP
+    from: []

--- a/applications/workspaces/upstream/controller/overlays/istio-prometheus/kustomization.yaml
+++ b/applications/workspaces/upstream/controller/overlays/istio-prometheus/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: kubeflow-workspaces
+
+resources:
+## see the 'istio' overlay for more configuration options
+- ../istio
+
+components:
+- ../../components/prometheus
+# NOTE: the common component should always be last, to ensure it labels all resources.
+- ../../components/common

--- a/applications/workspaces/upstream/controller/samples/codeserver_v1beta1_workspacekind.yaml
+++ b/applications/workspaces/upstream/controller/samples/codeserver_v1beta1_workspacekind.yaml
@@ -1,3 +1,12 @@
+## --> NOTE <--
+##
+## These are just example definitions for WorkspaceKind, please thoroughly vet
+## them and customize them for your usecase before using them in a production
+## setting!
+
+## For detailed documentation and configuration examples, see:
+## jupyterlab_v1beta1_workspacekind.yaml
+
 apiVersion: kubeflow.org/v1beta1
 kind: WorkspaceKind
 metadata:
@@ -10,12 +19,45 @@ spec:
       url: "https://upload.wikimedia.org/wikipedia/commons/9/9a/Visual_Studio_Code_1.35_icon.svg"
     logo:
       url: "https://upload.wikimedia.org/wikipedia/commons/9/9a/Visual_Studio_Code_1.35_icon.svg"
+
+  filterRules:
+  - scope: IMAGE_CONFIG
+    effect:
+      ui:
+        hide: true
+    match:
+     - matchNamespace:
+          selector:
+            matchExpressions:
+              - key: "nvidia.com/gpu"
+                operator: DoesNotExist
+     - matchImageConfig:
+          selector:
+            matchExpressions:
+              - key: "cuda_version"
+                operator: Exists
+
+  activityRules:
+    - config:
+        secondsSinceActive: 7200
+      match: {}
+      effect:
+        pauseWorkspace: true
+
   podTemplate:
     podMetadata:
       labels: {}
       annotations: {}
-    serviceAccount:
-      name: "default-editor"
+    activityProbe:
+      minProbeIntervalSeconds: 300
+      probeIntervalSeconds: 3600
+      podExec:
+        timeoutSeconds: 60
+        script: |-
+          #!/usr/bin/env bash
+          # A mock probe that always reports activity (replace with real detection logic)
+          echo '{"has_activity": true}' > "$OUTPUT_JSON_PATH"
+          exit 0
     volumeMounts:
       home: "/home/jovyan"
     ports:
@@ -35,12 +77,16 @@ spec:
           medium: "Memory"
     securityContext:
       fsGroup: 100
+      seccompProfile:
+        type: RuntimeDefault
     containerSecurityContext:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
           - ALL
       runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
     options:
       imageConfig:
         spawner:

--- a/applications/workspaces/upstream/controller/samples/common/kustomization.yaml
+++ b/applications/workspaces/upstream/controller/samples/common/kustomization.yaml
@@ -5,5 +5,4 @@ resources:
 - workspace_data_pvc.yaml
 - workspace_home_pvc.yaml
 - workspace_secret.yaml
-- workspace_service_account.yaml
 - workspacekind_imagesource_configmap.yaml

--- a/applications/workspaces/upstream/controller/samples/common/workspace_service_account.yaml
+++ b/applications/workspaces/upstream/controller/samples/common/workspace_service_account.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: default-editor

--- a/applications/workspaces/upstream/controller/samples/jupyterlab_v1beta1_workspace.yaml
+++ b/applications/workspaces/upstream/controller/samples/jupyterlab_v1beta1_workspace.yaml
@@ -1,3 +1,9 @@
+## --> NOTE <--
+##
+## These are just example definitions for Workspace, please thoroughly vet
+## them and customize them for your usecase before using them in a production
+## setting!
+
 apiVersion: kubeflow.org/v1beta1
 kind: Workspace
 metadata:
@@ -5,6 +11,9 @@ metadata:
 spec:
   ## if the workspace is paused (no pods running)
   paused: false
+
+  ## an optional human-readable name, displayed in the UI instead of metadata.name
+  displayName: "Example JupyterLab Workspace"
 
   ## the WorkspaceKind to use
   kind: "jupyterlab"

--- a/applications/workspaces/upstream/controller/samples/jupyterlab_v1beta1_workspacekind.yaml
+++ b/applications/workspaces/upstream/controller/samples/jupyterlab_v1beta1_workspacekind.yaml
@@ -1,8 +1,15 @@
+## --> NOTE <--
+##
+## These are just example definitions for WorkspaceKind, please thoroughly vet
+## them and customize them for your usecase before using them in a production
+## setting!
+
 apiVersion: kubeflow.org/v1beta1
 kind: WorkspaceKind
 metadata:
   name: jupyterlab
 spec:
+
   ## ================================================================
   ## SPAWNER CONFIGS
   ##  - how the WorkspaceKind is displayed in the Workspace Spawner UI
@@ -47,6 +54,88 @@ spec:
       #   mediaType: "image/svg+xml"
 
   ## ================================================================
+  ## FILTER RULES
+  ##  - admin-defined rules used by the backend API server to dynamically filter
+  ##    which WorkspaceKinds, imageConfig values, and podConfig values are visible
+  ##    or allowed in a given context
+  ##  - the controller does NOT evaluate these rules, it only persists and validates them
+  ## ================================================================
+  filterRules:
+
+    ## hide this WorkspaceKind in namespaces which are not labeled 'workspace_team=team_1'
+    - scope: WORKSPACE_KIND
+      effect:
+        ui:
+          hide: true
+      match:
+        - matchNamespace:
+            selector:
+              matchExpressions:
+                - key: "workspace_team"
+                  operator: NotIn
+                  values: ["team_1"]
+
+  ## ================================================================
+  ## ACTIVITY RULES
+  ##  - policies for handling inactivity in Workspaces of this kind
+  ##  - rules are evaluated sequentially from top to bottom (first-match-wins semantics)
+  ##    independently for each configured effect type (e.g., pauseWorkspace)
+  ## ================================================================
+  activityRules:
+
+    ## activityRule to pause workspaces which (AND)
+    ##  - have the namespaces with the label 'tier=development' set
+    ##  - have been running for at least 5 minutes (300 seconds)
+    ##  - have been inactive for at least 2 hours (7200 seconds)
+    - config:
+        secondsSinceActive: 7200
+        minRunningSeconds: 300
+      match:
+        matchNamespace:
+          selector:
+            matchLabels:
+              tier: development
+      effect:
+        pauseWorkspace: true
+
+    ## activityRule to pause workspaces which (AND)
+    ##  - the podconfig has the label 'gpu: "1"' set
+    ##  - have been running for at least 5 minutes (300 seconds)
+    ##  - have been inactive for at least 1 hour (3600 seconds)
+    #- config:
+    #    secondsSinceActive: 3600
+    #    minRunningSeconds: 300
+    #  match:
+    #    matchPodConfig:
+    #      selector:
+    #        matchLabels:
+    #          gpu: "1"
+    #  effect:
+    #    pauseWorkspace: true
+
+    ## activityRule to exempt from pausing workspaces which (AND)
+    ##  - have the namespaces with the label 'tier=production' set
+    #- config:
+    #  match:
+    #    matchNamespace:
+    #      selector:
+    #        matchLabels:
+    #          tier: production
+    #  effect:
+    #    pauseWorkspace: false
+
+    ## catch-all activityRule to pause workspaces which (AND)
+    ##  - have been inactive for at least 1 day
+    ##  - are not matched to any of the above pauseWorkspace rules
+    - config:
+        secondsSinceActive: 86400
+      ## empty match (`match: {}` or omitted `match`) matches all Workspaces.
+      ## At most one catch-all rule is allowed per effect type, and it must be the last rule.
+      match: {}
+      effect:
+        pauseWorkspace: true
+
+  ## ================================================================
   ## DEFINITION CONFIGS
   ##  - currently the only supported type is `podTemplate`
   ##  - in the future, there will be MORE types like `virtualMachine`
@@ -63,52 +152,51 @@ spec:
         my-workspace-kind-annotation: "my-value"
 
     ## service account configs for Workspace Pods
+    ##  - each Workspace runs as its own ServiceAccount named "ws-{WORKSPACE_NAME}",
+    ##    which the controller creates, owns, and deletes along with the Workspace
+    ##  - the resolved name is reported in the Workspace
+    ##    `status.podTemplatePod.serviceAccountName`
     ##
-    serviceAccount:
-
-      ## the name of the ServiceAccount (NOT MUTABLE)
-      ##  - this Service Account MUST already exist in the Namespace
-      ##    of the Workspace, the controller will NOT create it
-      ##  - we will not show this WorkspaceKind in the Spawner UI
-      ##    if the SA does not exist in the Namespace
-      ##
-      name: "default-editor"
-
-    ## activity culling configs (MUTABLE)
-    ##  - for pausing inactive Workspaces
+    ## NOTE: commented out because these ClusterRoles are provided by the Kubeflow
+    ##       platform, they do NOT exist in a standalone install of this controller
     ##
-    culling:
+    #serviceAccount:
+    #
+    #  ## ClusterRoles to grant to the ServiceAccount of each Workspace (MUTABLE)
+    #  ##  - each entry becomes a RoleBinding in the Namespace of the Workspace, so the
+    #  ##    permissions are scoped to that Namespace and are NOT cluster-wide
+    #  ##  - these are ClusterRole names, NOT ServiceAccount names
+    #  ##
+    #  clusterRoles:
+    #    - name: "kubeflow-view"
 
-      ## if the culling feature is enabled
+    ## activity probe configs (MUTABLE)
+    ##  - determines how to detect activity in the Workspace
+    ##
+    activityProbe:
+
+      ## determines the minimum period in seconds between each Workspace probe
       ##
-      enabled: true
+      minProbeIntervalSeconds: 300
 
-      ## the maximum number of seconds a Workspace can be inactive
+      ## determines the desired period in seconds between each Workspace probe
       ##
-      maxInactiveSeconds: 86400
+      probeIntervalSeconds: 3600
 
-      ## the probe used to determine if the Workspace is active
+      ## OPTION 1: a script-based probe executed in the Pod
       ##
-      activityProbe:
+      #podExec:
+      #  timeoutSeconds: 60
+      #  script: |-
+      #    #!/usr/bin/env bash
+      #    echo '{"has_activity": true}' > "$OUTPUT_JSON_PATH"
+      #    exit 0
 
-        ## OPTION 1: a shell command probe
-        ##  - if the Workspace had activity in the last 60 seconds this command
-        ##    should return status 0, otherwise it should return status 1
-        ##
-        #exec:
-        #  command:
-        #    - "bash"
-        #    - "-c"
-        #    - "exit 0"
-
-        ## OPTION 2: a Jupyter-specific probe
-        ##  - will poll the `/api/status` endpoint of the Jupyter API, and use the `last_activity` field
-        ##    https://github.com/jupyter-server/jupyter_server/blob/v2.13.0/jupyter_server/services/api/handlers.py#L62-L67
-        ##  - note, users need to be careful that their other probes don't trigger a "last_activity" update
-        ##    e.g. they should only check the health of Jupyter using the `/api/status` endpoint
-        ##
-        jupyter:
-          lastActivity: true
+      ## OPTION 2: a Jupyter-specific API probe
+      ##
+      jupyter:
+        lastActivity: true
+        portId: "jupyterlab"
 
     ## standard probes to determine Container health (MUTABLE)
     ##  - spec for Probe:
@@ -212,6 +300,8 @@ spec:
     ##
     securityContext:
       fsGroup: 100
+      seccompProfile:
+        type: RuntimeDefault
 
     ## container SecurityContext for Workspace Pods (MUTABLE)
     ##  - spec for SecurityContext:
@@ -223,6 +313,8 @@ spec:
         drop:
           - ALL
       runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
 
     ## ==============================================================
     ## WORKSPACE OPTIONS

--- a/applications/workspaces/upstream/controller/samples/rstudio_v1beta1_workspacekind.yaml
+++ b/applications/workspaces/upstream/controller/samples/rstudio_v1beta1_workspacekind.yaml
@@ -1,3 +1,12 @@
+## --> NOTE <--
+##
+## These are just example definitions for WorkspaceKind, please thoroughly vet
+## them and customize them for your usecase before using them in a production
+## setting!
+
+## For detailed documentation and configuration examples, see:
+## jupyterlab_v1beta1_workspacekind.yaml
+
 apiVersion: kubeflow.org/v1beta1
 kind: WorkspaceKind
 metadata:
@@ -10,12 +19,45 @@ spec:
       url: "https://upload.wikimedia.org/wikipedia/commons/1/1b/R_logo.svg"
     logo:
       url: "https://upload.wikimedia.org/wikipedia/commons/1/1b/R_logo.svg"
+
+  filterRules:
+    - scope: POD_CONFIG
+      effect:
+        ui:
+          hide: true
+      match:
+        - matchImageConfig:
+            selector:
+              matchExpressions:
+                - key: "cuda_version"
+                  operator: DoesNotExist
+        - matchPodConfig:
+            selector:
+              matchExpressions:
+                - key: "gpu"
+                  operator: Exists
+
+  activityRules:
+    - config:
+        secondsSinceActive: 7200
+      match: {}
+      effect:
+        pauseWorkspace: true
+
   podTemplate:
     podMetadata:
       labels: {}
       annotations: {}
-    serviceAccount:
-      name: "default-editor"
+    activityProbe:
+      minProbeIntervalSeconds: 300
+      probeIntervalSeconds: 3600
+      podExec:
+        timeoutSeconds: 60
+        script: |-
+          #!/usr/bin/env bash
+          # A mock probe that always reports activity (replace with real detection logic)
+          echo '{"has_activity": true}' > "$OUTPUT_JSON_PATH"
+          exit 0
     volumeMounts:
       home: "/home/jovyan"
     ports:
@@ -38,12 +80,16 @@ spec:
           medium: "Memory"
     securityContext:
       fsGroup: 100
+      seccompProfile:
+        type: RuntimeDefault
     containerSecurityContext:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
           - ALL
       runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
     options:
       imageConfig:
         spawner:

--- a/applications/workspaces/upstream/frontend/base/kustomization.yaml
+++ b/applications/workspaces/upstream/frontend/base/kustomization.yaml
@@ -16,4 +16,4 @@ labels:
 images:
 - name: workspaces-frontend
   newName: ghcr.io/kubeflow/notebooks/workspaces-frontend
-  newTag: v2.0.0-alpha.3
+  newTag: v2.0.0-beta.0

--- a/applications/workspaces/upstream/frontend/components/common/kustomization.yaml
+++ b/applications/workspaces/upstream/frontend/components/common/kustomization.yaml
@@ -4,6 +4,9 @@ kind: Component
 labels:
 - includeSelectors: true
   pairs:
-    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: workspaces-frontend
     app.kubernetes.io/part-of: kubeflow-workspaces
+- includeSelectors: false
+  includeTemplates: true
+  pairs:
+    app.kubernetes.io/managed-by: kustomize

--- a/applications/workspaces/upstream/frontend/components/istio/authorization-policy.yaml
+++ b/applications/workspaces/upstream/frontend/components/istio/authorization-policy.yaml
@@ -8,7 +8,6 @@ spec:
     matchLabels:
       app: workspaces-frontend
       app.kubernetes.io/component: ui
-      app.kubernetes.io/managed-by: kustomize
       app.kubernetes.io/name: workspaces-frontend
       app.kubernetes.io/part-of: kubeflow-workspaces
   rules:

--- a/scripts/synchronize-kubeflow-workspaces-manifests.sh
+++ b/scripts/synchronize-kubeflow-workspaces-manifests.sh
@@ -6,7 +6,7 @@ setup_error_handling
 COMPONENT_NAME="workspaces"
 REPOSITORY_NAME="kubeflow/notebooks"
 REPOSITORY_URL="https://github.com/kubeflow/notebooks.git"
-COMMIT="v2.0.0-alpha.3"
+COMMIT="v2.0.0-beta.0"
 REPOSITORY_DIRECTORY="$COMPONENT_NAME"
 SOURCE_DIRECTORY=${SOURCE_DIRECTORY:=/tmp/${COMPONENT_NAME}}
 BRANCH_NAME=${BRANCH_NAME:=synchronize-${COMPONENT_NAME}-manifests-${COMMIT?}}
@@ -36,7 +36,7 @@ for component in {backend,frontend,controller}; do
         "applications/workspaces/upstream/${component}" ""
 done
 
-commit_changes "$MANIFESTS_DIRECTORY" "Update ${REPOSITORY_NAME} manifests from ${COMMIT}" \
+commit_changes "$MANIFESTS_DIRECTORY" "Update ${REPOSITORY_NAME} manifests to ${COMMIT}" \
   "${SCRIPT_DIRECTORY}/synchronize-kubeflow-workspaces-manifests.sh" \
   "applications/workspaces/upstream/"
 echo "Synchronization completed successfully."

--- a/tests/workspacekind.test.yaml
+++ b/tests/workspacekind.test.yaml
@@ -1,0 +1,115 @@
+# Test-only copy of the upstream JupyterLab WorkspaceKind sample
+# (applications/workspaces/upstream/controller/samples/jupyterlab_v1beta1_workspacekind.yaml),
+# trimmed to what the pipeline run test needs. The only functional difference
+# from the upstream sample is the `serviceAccount.clusterRoles` grant below.
+apiVersion: kubeflow.org/v1beta1
+kind: WorkspaceKind
+metadata:
+  name: jupyterlab
+spec:
+  spawner:
+    displayName: "JupyterLab Notebook"
+    description: "A Workspace which runs JupyterLab in a Pod"
+    hidden: false
+    deprecated: false
+    icon:
+      url: "https://jupyter.org/assets/favicons/apple-touch-icon-152x152.png"
+    logo:
+      url: "https://upload.wikimedia.org/wikipedia/commons/3/38/Jupyter_logo.svg"
+
+  podTemplate:
+    podMetadata:
+      labels:
+        my-workspace-kind-label: "my-value"
+      annotations:
+        my-workspace-kind-annotation: "my-value"
+    # Grant the per-Workspace ServiceAccount ("ws-{WORKSPACE_NAME}") access to
+    # Kubeflow Pipelines. As of Workspaces v2.0.0-beta.0 this ServiceAccount is
+    # no longer automatically granted the Kubeflow ClusterRoles (as the old
+    # "default-editor" was), so the pipeline run test needs these bindings to
+    # get/list/create experiments and runs. We bind only the pipeline-scoped
+    # ClusterRoles rather # than the broad "kubeflow-edit" to keep the grant
+    # minimal.
+    serviceAccount:
+      clusterRoles:
+        # get/list experiments and runs
+        - name: "kubeflow-pipelines-view"
+        # create/delete/archive experiments and runs
+        - name: "kubeflow-pipelines-edit"
+    activityProbe:
+      minProbeIntervalSeconds: 300
+      probeIntervalSeconds: 3600
+      jupyter:
+        lastActivity: true
+        portId: "jupyterlab"
+    volumeMounts:
+      home: "/home/jovyan"
+    ports:
+      - id: "jupyterlab"
+        defaultDisplayName: "JupyterLab"
+        protocol: "HTTP"
+        httpProxy:
+          removePathPrefix: false
+          requestHeaders: {}
+    extraEnv:
+      - name: "NB_PREFIX"
+        value: |-
+          {{ httpPathPrefix "jupyterlab" }}
+    extraVolumeMounts:
+      - name: "dshm"
+        mountPath: "/dev/shm"
+    extraVolumes:
+      - name: "dshm"
+        emptyDir:
+          medium: "Memory"
+    securityContext:
+      fsGroup: 100
+      seccompProfile:
+        type: RuntimeDefault
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+    options:
+      imageConfig:
+        spawner:
+          default: "jupyter-scipy:v1.10.0"
+        values:
+          - id: "jupyter-scipy:v1.10.0"
+            spawner:
+              displayName: "jupyter-scipy:v1.10.0"
+              description: "JupyterLab, with SciPy Packages"
+              labels:
+                - key: "python_version"
+                  value: "3.11.11"
+            spec:
+              image: "ghcr.io/kubeflow/kubeflow/notebook-servers/jupyter-scipy:v1.10.0"
+              imagePullPolicy: "IfNotPresent"
+              ports:
+                - id: "jupyterlab"
+                  port: 8888
+      podConfig:
+        spawner:
+          default: "tiny_cpu"
+        values:
+          - id: "tiny_cpu"
+            spawner:
+              displayName: "Tiny CPU"
+              description: "Pod with 0.1 CPU, 128 Mb RAM"
+              labels:
+                - key: "cpu"
+                  value: "100m"
+                - key: "memory"
+                  value: "128Mi"
+            spec:
+              affinity: {}
+              nodeSelector: {}
+              tolerations: []
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 128Mi

--- a/tests/workspaces_pipeline_run_test.sh
+++ b/tests/workspaces_pipeline_run_test.sh
@@ -3,7 +3,7 @@ set -euxo pipefail
 
 KF_PROFILE=${1:-kubeflow-user-example-com}
 
-kubectl apply -f applications/workspaces/upstream/controller/samples/jupyterlab_v1beta1_workspacekind.yaml
+kubectl apply -f tests/workspacekind.test.yaml
 kubectl apply -f tests/workspace.test.kubeflow-user-example-com.yaml
 kubectl wait --for=jsonpath='{.status.state}'=Running \
   workspace/test -n "${KF_PROFILE}" \


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes

Synchronize the changes from the latest Kubeflow Workspaces release:
https://github.com/kubeflow/notebooks/releases/tag/v2.0.0-beta.0

## 📦 Dependencies

_None_

## 🐛 Related Issues

_None_

## ✅ Contributor Checklist

- [x] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/community-distribution#prerequisites).
- [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
- [x] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).
