### PR TITLE
fix(spark): add sparkconnects to the aggregated Spark ClusterRoles

### DIFF
--- a/applications/spark/spark-operator/base/aggregated-roles.yaml
+++ b/applications/spark/spark-operator/base/aggregated-roles.yaml
@@ -24,6 +24,7 @@ rules:
     resources:
       - sparkapplications
       - scheduledsparkapplications
+      - sparkconnects
     verbs:
       - create
       - delete
@@ -37,6 +38,7 @@ rules:
     resources:
       - sparkapplications/status
       - scheduledsparkapplications/status
+      - sparkconnects/status
     verbs:
       - get
 ---
@@ -54,6 +56,7 @@ rules:
     resources:
       - sparkapplications
       - scheduledsparkapplications
+      - sparkconnects
     verbs:
       - get
       - list
@@ -63,6 +66,7 @@ rules:
     resources:
       - sparkapplications/status
       - scheduledsparkapplications/status
+      - sparkconnects/status
     verbs:
       - get
 ---

--- a/tests/spark_test.sh
+++ b/tests/spark_test.sh
@@ -44,3 +44,25 @@ kubectl -n $NAMESPACE logs pod/spark-pi-python-driver
 
 # Delete Spark Deployment
 kubectl -n $NAMESPACE delete -f "$SPARK_APPLICATION_YAML"
+
+
+# Verify the aggregated Spark ClusterRoles grant access to SparkConnect resources.
+# kubeflow-edit aggregates into default-editor and kubeflow-view into default-viewer,
+# so these assert what a notebook user can actually do in their own namespace.
+EDITOR="system:serviceaccount:${NAMESPACE}:default-editor"
+VIEWER="system:serviceaccount:${NAMESPACE}:default-viewer"
+
+for VERB in create delete get list patch update watch; do
+    kubectl auth can-i "$VERB" sparkconnects --as="$EDITOR" -n "$NAMESPACE" | grep -qx yes
+done
+
+for VERB in get list watch; do
+    kubectl auth can-i "$VERB" sparkconnects --as="$VIEWER" -n "$NAMESPACE" | grep -qx yes
+done
+
+# Viewers must not be able to modify SparkConnect resources.
+for VERB in create delete patch update; do
+    ! kubectl auth can-i "$VERB" sparkconnects --as="$VIEWER" -n "$NAMESPACE" | grep -qx yes
+done
+
+echo "Aggregated Spark ClusterRole permissions for sparkconnects verified."

--- a/tests/spark_test.sh
+++ b/tests/spark_test.sh
@@ -62,9 +62,13 @@ for VERB in create delete get list patch update watch; do
     kubectl auth can-i "$VERB" sparkconnects --as="$EDITOR" -n "$NAMESPACE" | grep -qx yes
 done
 
+kubectl auth can-i get sparkconnects/status --as="$EDITOR" -n "$NAMESPACE" | grep -qx yes
+
 for VERB in get list watch; do
     kubectl auth can-i "$VERB" sparkconnects --as="$VIEWER" -n "$NAMESPACE" | grep -qx yes
 done
+
+kubectl auth can-i get sparkconnects/status --as="$VIEWER" -n "$NAMESPACE" | grep -qx yes
 
 # Viewers must not be able to modify SparkConnect resources.
 for VERB in create delete patch update; do

--- a/tests/spark_test.sh
+++ b/tests/spark_test.sh
@@ -47,10 +47,16 @@ kubectl -n $NAMESPACE delete -f "$SPARK_APPLICATION_YAML"
 
 
 # Verify the aggregated Spark ClusterRoles grant access to SparkConnect resources.
-# kubeflow-edit aggregates into default-editor and kubeflow-view into default-viewer,
-# so these assert what a notebook user can actually do in their own namespace.
+# kubeflow-spark-edit aggregates into kubeflow-edit, which is bound to default-editor.
+# Profiles do not create a default-viewer, so bind a dedicated viewer identity here.
 EDITOR="system:serviceaccount:${NAMESPACE}:default-editor"
-VIEWER="system:serviceaccount:${NAMESPACE}:default-viewer"
+VIEWER_SERVICE_ACCOUNT_NAME="spark-permissions-viewer"
+trap 'kubectl -n "$NAMESPACE" delete rolebinding "$VIEWER_SERVICE_ACCOUNT_NAME" --ignore-not-found; kubectl -n "$NAMESPACE" delete serviceaccount "$VIEWER_SERVICE_ACCOUNT_NAME" --ignore-not-found' EXIT
+kubectl -n "$NAMESPACE" create serviceaccount "$VIEWER_SERVICE_ACCOUNT_NAME"
+kubectl -n "$NAMESPACE" create rolebinding "$VIEWER_SERVICE_ACCOUNT_NAME" \
+    --clusterrole=kubeflow-view \
+    --serviceaccount="${NAMESPACE}:${VIEWER_SERVICE_ACCOUNT_NAME}"
+VIEWER="system:serviceaccount:${NAMESPACE}:${VIEWER_SERVICE_ACCOUNT_NAME}"
 
 for VERB in create delete get list patch update watch; do
     kubectl auth can-i "$VERB" sparkconnects --as="$EDITOR" -n "$NAMESPACE" | grep -qx yes


### PR DESCRIPTION
**What this PR does / why we need it**:

`kubeflow-spark-edit` and `kubeflow-spark-view` grant `sparkapplications` and `scheduledsparkapplications`, but not `sparkconnects`. As a result `default-editor` cannot create a `SparkConnect` resource in its own profile namespace:

```
sparkconnects.sparkoperator.k8s.io is forbidden: User
"system:serviceaccount:kubeflow-user-example-com:default-editor" cannot create resource
"sparkconnects" in API group "sparkoperator.k8s.io" in the namespace
"kubeflow-user-example-com"
```

The aggregation labels are already correct, so this is only a missing resource — presumably because `SparkConnect` is a newer CRD than these roles. The CRD itself ships in `resources.yaml`, and the operator's own ClusterRole already covers `sparkconnects`, `sparkconnects/status` and `sparkconnects/finalizers`; it is the user-facing roles that were not updated.

This matters because Spark Connect is the path for interactive Spark from a notebook, and the Kubeflow SDK's `SparkClient.connect()` creates a `SparkConnect` resource. On a stock install a notebook user cannot start a session without an administrator granting RBAC first.

**Changes**

Four added lines in `applications/spark/spark-operator/base/aggregated-roles.yaml`:

- `sparkconnects` and `sparkconnects/status` in `kubeflow-spark-edit`, which also aggregates into `kubeflow-spark-admin`
- the same two in `kubeflow-spark-view`, with its existing read-only verbs

The verbs match what is already granted for `sparkapplications` in each role, so users get the same level of access to `SparkConnect` as they have to `SparkApplication`. `kubeflow-spark-admin` needs no change — its rules are empty by design and it inherits through aggregation.

**Verification**

Before:

```console
$ kubectl auth can-i create sparkconnects \
    --as=system:serviceaccount:kubeflow-user-example-com:default-editor \
    -n kubeflow-user-example-com
no
```

After applying this change:

```console
$ kubectl auth can-i create sparkconnects \
    --as=system:serviceaccount:kubeflow-user-example-com:default-editor \
    -n kubeflow-user-example-com
yes
```
Screenshot for proof:
<img width="1151" height="307" alt="Screenshot 2026-08-22 at 3 05 10 am" src="https://github.com/user-attachments/assets/cfcde04e-1d67-426b-a1c8-dfc2cb8f7cd8" />


Tested on Kubeflow v1.10.0, Kubernetes v1.35.0 (kind), Spark Operator 2.3.0.

**Which issue(s) this PR fixes**:

Fixes #3585 

**Checklist**:

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.