### PR TITLE
spark: regenerate resources.yaml with Helm v4 and pin the toolchain

### DIFF
--- a/applications/spark/spark-operator/base/resources.yaml
+++ b/applications/spark/spark-operator/base/resources.yaml
@@ -25716,6 +25716,7 @@ metadata:
     app.kubernetes.io/version: "2.5.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
+
 ---
 # Source: spark-operator/templates/webhook/serviceaccount.yaml
 apiVersion: v1
@@ -25731,6 +25732,7 @@ metadata:
     app.kubernetes.io/version: "2.5.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: webhook
+
 ---
 # Source: spark-operator/templates/controller/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -26065,6 +26067,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: spark-operator-controller
+
 ---
 # Source: spark-operator/templates/webhook/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -26087,6 +26090,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: spark-operator-webhook
+
 ---
 # Source: spark-operator/templates/webhook/service.yaml
 apiVersion: v1
@@ -26109,6 +26113,7 @@ spec:
   - port: 9443
     targetPort: "webhook"
     name: webhook
+
 ---
 # Source: spark-operator/templates/controller/deployment.yaml
 apiVersion: apps/v1
@@ -26211,6 +26216,7 @@ spec:
       automountServiceAccountToken: true
       securityContext:
         fsGroup: 185
+
 ---
 # Source: spark-operator/templates/webhook/deployment.yaml
 apiVersion: apps/v1
@@ -26305,6 +26311,7 @@ spec:
       automountServiceAccountToken: true
       securityContext:
         fsGroup: 185
+
 ---
 # Source: spark-operator/templates/webhook/mutatingwebhookconfiguration.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -26386,6 +26393,7 @@ webhooks:
     resources: ["sparkconnects"]
     operations: ["CREATE", "UPDATE"]
   timeoutSeconds: 10
+
 ---
 # Source: spark-operator/templates/webhook/validatingwebhookconfiguration.yaml
 apiVersion: admissionregistration.k8s.io/v1

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -7,6 +7,17 @@ setup_error_handling() {
   IFS=$'\n\t'
 }
 
+# Helm v4 renders template files differently from v3, so a chart must be
+# rendered with the major version that the idempotence workflow pins.
+require_helm_major_version() {
+  local version
+  version="$(helm version --template '{{.Version}}')"
+  if [[ "$version" != v"$1".* ]]; then
+    echo "ERROR: Helm v$1.x required to match the idempotence workflow, found $version." >&2
+    exit 1
+  fi
+}
+
 # Check if the git repository has uncommitted changes
 check_uncommitted_changes() {
   if [ -n "$(git status --porcelain)" ]; then

--- a/scripts/synchronize-spark-operator-manifests.sh
+++ b/scripts/synchronize-spark-operator-manifests.sh
@@ -14,6 +14,7 @@ MANIFESTS_DIRECTORY=$(dirname $SCRIPT_DIRECTORY)
 DESTINATION_MANIFESTS_PATH="applications/spark/${COMPONENT_NAME}/base"
 SOURCE_TEXT="\[[^]]*\](https://github.com/${REPOSITORY_NAME}/tree/[^)]*)"
 DESTINATION_TEXT="\[${COMMIT#v}\](https://github.com/${REPOSITORY_NAME}/tree/${COMMIT})"
+require_helm_major_version 4
 create_branch "$BRANCH_NAME"
 clone_and_checkout "$SOURCE_DIRECTORY" "$REPOSITORY_URL" "$REPOSITORY_DIRECTORY" "$COMMIT"
 helm template -n kubeflow --include-crds spark-operator \

--- a/tests/resynchronize-upstream-changes.py
+++ b/tests/resynchronize-upstream-changes.py
@@ -86,7 +86,11 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if args.all:
-        upstream_scripts = set(path_to_synchronization_script.values())
+        upstream_scripts = {
+            script
+            for scripts in path_to_synchronization_script.values()
+            for script in scripts
+        }
     else:
         upstream_scripts = find_upstream_scripts(args.files)
     failed = False


### PR DESCRIPTION
## Problem

Any pull request touching `applications/spark/` fails `upstream_synchronization_idempotence_test`, through no fault of its own. [#3586](https://github.com/kubeflow/community-distribution/pull/3586) and [#3575](https://github.com/kubeflow/community-distribution/pull/3575) are blocked today.

`applications/spark/spark-operator/base/resources.yaml` was generated with Helm v3. The workflow pins Helm v4.2.2, and v4 renders eight extra blank lines. Nothing else differs.

The root cause: the script that **generates** the file pins no Helm version, while the workflow that **verifies** it pins v4.2.2.

## Changes

1. `resources.yaml` regenerated with Helm v4.2.2. Whitespace only.
2. `scripts/library.sh` gains `require_helm_major_version`, called from `scripts/synchronize-spark-operator-manifests.sh`, so the script fails early instead of writing manifests the workflow rejects.
3. `tests/resynchronize-upstream-changes.py`: the `--all` flag built a set of tuples and crashed in `subprocess.Popen`. Nothing calls it today, which is why the bug was never seen. Happy to drop this from the pull request if you would rather keep it to the Spark fix.

## Two things worth knowing

**The idempotence workflow only checks changed paths.** A component nobody touches is never revalidated, which is why this drift sat unnoticed for eighteen days until Vikas opened the first Spark pull request since. A scheduled full run would catch that class of problem, but that is a change to how CI behaves and I did not want to add it without your agreement. Happy to open an issue to discuss it if you think it is worth having.

**Katib has an unrelated drift.** Running `scripts/synchronize-katib-manifests.sh` reverts deliberate fixes in `applications/katib/upstream/components/mysql/mysql.yaml` from [#3310](https://github.com/kubeflow/community-distribution/pull/3310), [#3050](https://github.com/kubeflow/community-distribution/pull/3050) and [#3307](https://github.com/kubeflow/community-distribution/pull/3307). Found while checking whether other components had the same Helm problem. They do not, this is a separate issue and out of scope here.

## Verification

Resynchronization after committing is idempotent. Both unit test files pass. The guard fails on Helm v3.16.3 and passes on v4.2.2. `shellcheck`, `yamllint` and `black` clean.
