### PR TITLE
fix(spark): correct sidecar injection label key on the SparkApplication

### DIFF
--- a/applications/spark/sparkapplication_example.yaml
+++ b/applications/spark/sparkapplication_example.yaml
@@ -33,7 +33,7 @@ spec:
     cores: 1
     memory: 512m
     labels:
-      sidecar.istio.io.inject: "false"
+      sidecar.istio.io/inject: "false"
     securityContext:
       capabilities:
         drop:


### PR DESCRIPTION
**What this PR does / why we need it**:

The executor label in `applications/spark/sparkapplication_example.yaml` reads `sidecar.istio.io.inject` where the driver and the SparkApplication itself both use `sidecar.istio.io/inject`. Istio matches on the slash form, so the dotted key has no effect. It is the only occurrence of that spelling in the repository.

**Which issue(s) this PR fixes**:

Fixes #3589 

**Checklist**:

- [x] I have conducted a self-review of my own code.
- [ ] I have updated documentation accordingly.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] Existing unit tests pass locally with my changes.