### PR TITLE
tests: reject unknown comparison descriptor fields at load

### DIFF
--- a/tests/comparison_descriptors_test.py
+++ b/tests/comparison_descriptors_test.py
@@ -72,6 +72,39 @@ class MalformedDescriptorTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.load("scenarios:\n  a:\n    values: v.yaml\n")
 
+    def test_an_unknown_top_level_field_is_rejected(self):
+        """A misspelled field would otherwise be replaced by its default and
+        silently change which manifests are compared."""
+        with self.assertRaises(ValueError) as error:
+            self.load(
+                "helmUsesKustomizeNameHash: false\n"
+                "scenarios:\n  a:\n    kustomize: [x]\n"
+            )
+        self.assertIn("unknown", str(error.exception))
+
+    def test_an_unknown_scenario_field_is_rejected(self):
+        for field in ("value: v.yaml", "excludeKind: [Namespace]"):
+            with self.subTest(field=field):
+                with self.assertRaises(ValueError):
+                    self.load(f"scenarios:\n  a:\n    kustomize: [x]\n    {field}\n")
+
+    def test_a_declared_values_file_must_exist_in_the_chart(self):
+        """helm template ignores nothing louder than a missing --values file
+        at load time; catching the typo here names the file and the rule."""
+        with tempfile.TemporaryDirectory() as directory:
+            chart = Path(directory)
+            (chart / "ci").mkdir()
+            path = chart / "ci" / "comparison.yaml"
+            body = (
+                "component: x\nreleaseName: x\nnamespace: n\n"
+                "scenarios:\n  a:\n    kustomize: [x]\n    values: v.yaml\n"
+            )
+            path.write_text(body)
+            with self.assertRaises(ValueError):
+                comparison.load_descriptor(path)
+            (chart / "v.yaml").write_text("")
+            comparison.load_descriptor(path)
+
     def test_a_default_scenario_that_is_not_declared_is_rejected(self):
         """Katib's old default was 'base', a scenario Katib does not have, so
         comparing it without naming one could only ever fail."""
@@ -138,6 +171,35 @@ class MalformedAllowanceTest(unittest.TestCase):
     def test_an_ignored_labels_entry_without_keys_is_rejected(self):
         with self.assertRaises(ValueError):
             self.load("ignoredLabels:\n- reason: r\n")
+
+    def test_a_misspelled_ignored_labels_field_is_rejected(self):
+        """'podTemplate: true' would otherwise load, do nothing, and still
+        pass the staleness gate through its top-level match."""
+        with self.assertRaises(ValueError):
+            self.load("ignoredLabels:\n- keys: [a]\n  podTemplate: true\n  reason: r\n")
+
+    def test_a_non_list_action_value_is_rejected(self):
+        """A boolean would raise TypeError at comparison time; a scalar string
+        would be iterated character by character and never fire."""
+        for value in ("true", "checksum/config"):
+            with self.subTest(value=value):
+                with self.assertRaises(ValueError):
+                    self.load(
+                        "knownDifferences:\n"
+                        "- resource: Deployment/auth/dex\n"
+                        f"  ignorePodTemplateAnnotations: {value}\n"
+                        "  reason: r\n"
+                    )
+
+    def test_a_helm_only_entry_needs_a_well_formed_resource(self):
+        for body in (
+            "helmOnlyResources:\n- reason: r\n",
+            "helmOnlyResources:\n- resource: Secret\n  reason: r\n",
+            "helmOnlyResources:\n- resource: Secret/x\n  reasons: r\n  reason: r\n",
+        ):
+            with self.subTest(body=body):
+                with self.assertRaises(ValueError):
+                    self.load(body)
 
     def test_a_skip_entry_with_extra_fields_is_rejected(self):
         with self.assertRaises(ValueError):

--- a/tests/helm_kustomize_compare.py
+++ b/tests/helm_kustomize_compare.py
@@ -165,14 +165,19 @@ class ChartComparisonRules:
 
     def unexpected_helm_only(self, only_in_helm: set) -> set:
         """Filter Helm-side extras down to the undeclared ones."""
-        declared = {
-            entry["resource"]: f"helmOnlyResources[{index}]"
-            for index, entry in enumerate(self.helm_only_resources)
-        }
+        unexpected = set()
         for key in only_in_helm:
-            if key in declared:
-                self._fired.add(declared[key])
-        return {key for key in only_in_helm if key not in declared}
+            segments = key.split("/")
+            kind, namespace, name = (
+                segments if len(segments) == 3 else (segments[0], "", segments[1])
+            )
+            for index, entry in enumerate(self.helm_only_resources):
+                if resource_matches(entry["resource"], kind, namespace, name):
+                    self._fired.add(f"helmOnlyResources[{index}]")
+                    break
+            else:
+                unexpected.add(key)
+        return unexpected
 
     def unfired(self) -> List[str]:
         """Describe every declared allowance that matched nothing."""

--- a/tests/helm_kustomize_compare_test.py
+++ b/tests/helm_kustomize_compare_test.py
@@ -553,6 +553,20 @@ class HelmOnlyResourceTest(unittest.TestCase):
         self.assertEqual(unexpected, {"Secret/kubeflow/surprise"})
         self.assertEqual(extras_rules.unfired(), [])
 
+    def test_a_wildcard_entry_matches_as_the_contract_documents(self):
+        """Patterns carry * wildcards per segment, exactly as knownDifferences
+        patterns do; a two-segment pattern matches any namespace."""
+        extras_rules = rules(
+            helmOnlyResources=[{"resource": "Secret/*-webhook-cert", "reason": "t"}]
+        )
+
+        unexpected = extras_rules.unexpected_helm_only(
+            {"Secret/kubeflow/katib-webhook-cert", "Secret/kubeflow/surprise"}
+        )
+
+        self.assertEqual(unexpected, {"Secret/kubeflow/surprise"})
+        self.assertEqual(extras_rules.unfired(), [])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/run_helm_kustomize_comparison.py
+++ b/tests/run_helm_kustomize_comparison.py
@@ -80,15 +80,33 @@ def _validate_pattern(path, family, pattern):
         )
 
 
+def _reject_unknown_fields(path, context, mapping, allowed):
+    unknown = set(mapping) - allowed
+    if unknown:
+        raise ValueError(
+            f"{path}: unknown {context} fields: {', '.join(sorted(unknown))}"
+        )
+
+
 def _validate_allowances(path, descriptor):
     """Reject malformed declared allowances at load, not at comparison time."""
     for entry in descriptor.get("ignoredLabels") or []:
         _validate_reason(path, "ignoredLabels", entry)
+        _reject_unknown_fields(
+            path, "ignoredLabels", entry, {"reason", "keys", "podTemplates"}
+        )
         keys = entry.get("keys")
-        if not isinstance(keys, list) or not keys:
+        if (
+            not isinstance(keys, list)
+            or not keys
+            or not all(isinstance(key, str) and key for key in keys)
+        ):
             raise ValueError(
-                f"{path}: an ignoredLabels entry needs a non-empty 'keys' list"
+                f"{path}: an ignoredLabels entry needs a non-empty 'keys' list "
+                "of label keys"
             )
+        if not isinstance(entry.get("podTemplates", False), bool):
+            raise ValueError(f"{path}: ignoredLabels 'podTemplates' must be a boolean")
     for entry in descriptor.get("knownDifferences") or []:
         _validate_reason(path, "knownDifferences", entry)
         fields = set(entry) - {"reason"}
@@ -114,17 +132,26 @@ def _validate_allowances(path, descriptor):
             raise ValueError(
                 f"{path}: knownDifferences entry for {entry['resource']!r} declares no action"
             )
+        for action in actions:
+            value = entry[action]
+            if (
+                not isinstance(value, list)
+                or not value
+                or not all(isinstance(item, str) and item for item in value)
+            ):
+                raise ValueError(f"{path}: {action} must be a non-empty list of keys")
 
     for entry in descriptor.get("helmOnlyResources") or []:
         _validate_reason(path, "helmOnlyResources", entry)
-        if not entry.get("resource"):
-            raise ValueError(
-                f"{path}: every helmOnlyResources entry needs a 'resource'"
-            )
+        _reject_unknown_fields(path, "helmOnlyResources", entry, {"reason", "resource"})
+        _validate_pattern(path, "helmOnlyResources", entry.get("resource"))
 
     retained = descriptor.get("retainedCustomResourceDefinitions")
     if retained is not None:
         _validate_reason(path, "retainedCustomResourceDefinitions", retained)
+        _reject_unknown_fields(
+            path, "retainedCustomResourceDefinitions", retained, {"reason", "names"}
+        )
         names = retained.get("names")
         if not isinstance(names, list) or not names:
             raise ValueError(
@@ -136,6 +163,25 @@ def _validate_allowances(path, descriptor):
 def load_descriptor(path):
     """Read one descriptor, rejecting the mistakes that used to be possible."""
     descriptor = yaml.load(path.read_text(), Loader=_StrictLoader)
+    _reject_unknown_fields(
+        path,
+        "descriptor",
+        descriptor,
+        {
+            "component",
+            "releaseName",
+            "namespace",
+            "scenarios",
+            "defaultScenario",
+            "includeCustomResourceDefinitions",
+            "helmUsesKustomizeNameHashes",
+            "dependencyRepositories",
+            "ignoredLabels",
+            "knownDifferences",
+            "helmOnlyResources",
+            "retainedCustomResourceDefinitions",
+        },
+    )
     for field in ("component", "releaseName", "namespace", "scenarios"):
         if not descriptor.get(field):
             raise ValueError(f"{path}: missing {field!r}")
@@ -156,6 +202,20 @@ def load_descriptor(path):
         if not isinstance(targets, list) or not targets:
             raise ValueError(
                 f"{path}: scenario {name!r} must declare a list of Kustomize targets"
+            )
+        _reject_unknown_fields(
+            path,
+            f"scenario {name!r}",
+            scenario,
+            {"kustomize", "values", "onlyKinds", "excludeKinds"},
+        )
+        if (
+            "values" in scenario
+            and not (path.parent.parent / scenario["values"]).is_file()
+        ):
+            raise ValueError(
+                f"{path}: scenario {name!r} values file "
+                f"{scenario['values']!r} does not exist in the chart"
             )
         for field in ("onlyKinds", "excludeKinds"):
             if field in scenario and (

--- a/tests/run_helm_kustomize_comparison.py
+++ b/tests/run_helm_kustomize_comparison.py
@@ -209,14 +209,19 @@ def load_descriptor(path):
             scenario,
             {"kustomize", "values", "onlyKinds", "excludeKinds"},
         )
-        if (
-            "values" in scenario
-            and not (path.parent.parent / scenario["values"]).is_file()
-        ):
-            raise ValueError(
-                f"{path}: scenario {name!r} values file "
-                f"{scenario['values']!r} does not exist in the chart"
-            )
+        if "values" in scenario:
+            values = scenario["values"]
+            chart_directory = path.parent.parent.resolve()
+            if not isinstance(values, str) or not values:
+                raise ValueError(
+                    f"{path}: scenario {name!r} values must be a non-empty path in the chart"
+                )
+            values_path = (chart_directory / values).resolve()
+            if not values_path.is_relative_to(chart_directory) or not values_path.is_file():
+                raise ValueError(
+                    f"{path}: scenario {name!r} values file "
+                    f"{values!r} does not exist in the chart"
+                )
         for field in ("onlyKinds", "excludeKinds"):
             if field in scenario and (
                 not isinstance(scenario[field], list) or not scenario[field]

--- a/tests/run_helm_kustomize_comparison.py
+++ b/tests/run_helm_kustomize_comparison.py
@@ -217,7 +217,10 @@ def load_descriptor(path):
                     f"{path}: scenario {name!r} values must be a non-empty path in the chart"
                 )
             values_path = (chart_directory / values).resolve()
-            if not values_path.is_relative_to(chart_directory) or not values_path.is_file():
+            if (
+                not values_path.is_relative_to(chart_directory)
+                or not values_path.is_file()
+            ):
                 raise ValueError(
                     f"{path}: scenario {name!r} values file "
                     f"{values!r} does not exist in the chart"


### PR DESCRIPTION
## What this does

Follow-up to the descriptor harness ([#3577](https://github.com/kubeflow/community-distribution/pull/3577)), closing the five findings of its final Copilot review ([review 5067507448](https://github.com/kubeflow/community-distribution/pull/3577#pullrequestreview-5067507448)). A comparison descriptor decides what is compared, so a misspelled field must fail at load, not be silently replaced by a default.

- **Unknown fields are rejected at three levels**: the descriptor top level, each scenario, and each `ignoredLabels` entry. Previously `helmUsesKustomizeNameHash:` or `excludeKind:` loaded and were ignored.
- **Action values are typed**: `ignorePodTemplateAnnotations` and `compareDataAsYaml` must be non-empty lists of keys. Previously a boolean raised `TypeError` at comparison time and a scalar string was iterated character by character.
- **A declared scenario `values` file must exist in the chart.**
- **`helmOnlyResources` patterns now match with per-segment `*` wildcards**, through the same `resource_matches` used by `knownDifferences`, as `tests/README.md` already documents. Previously the mapping was exact string membership.
- `helmOnlyResources` patterns get the same shape validation (`Kind/name` or `Kind/namespace/name`) as every other pattern family.

## Verification

- `python3 tests/run_helm_kustomize_comparison.py all` — all eleven components, every scenario, green under Helm 4.2.2: every shipping descriptor loads under the stricter rules.
- `python3 tests/comparison_descriptors_test.py` — 24 tests, including new guards for each rejection.
- `python3 tests/helm_kustomize_compare_test.py` (both invocation forms) — includes a new wildcard-matching test.
- `black --check tests/`, `git diff --check` clean.