### PR TITLE
test: add the Helm end-to-end integration workflow

### DIFF
--- a/.github/workflows/helm_kubeflow_integration_test.yaml
+++ b/.github/workflows/helm_kubeflow_integration_test.yaml
@@ -121,6 +121,19 @@ jobs:
     - name: Run Trainer Test
       run: ./tests/trainer_test.sh "${KF_PROFILE}"
 
+    - name: Collect Trainer webhook diagnostics
+      if: failure()
+      continue-on-error: true
+      run: |
+        kubectl get namespace kubeflow-system -o yaml
+        kubectl -n kubeflow-system get pods --show-labels
+        kubectl -n kubeflow-system get networkpolicies
+        kubectl get mutatingwebhookconfigurations -o name
+        kubectl get mutatingwebhookconfiguration istio-sidecar-injector -o yaml | sed -n '/namespaceSelector/,/^  sideEffects/p' || true
+        kubectl -n istio-system get pods --show-labels
+        kubectl -n istio-system logs deployment/istiod --tail=100 | grep -iE "inject|kubeflow-system|error" || true
+        kubectl -n kubeflow-system describe pod -l app.kubernetes.io/name=trainer | tail -40
+
     - name: Test Dex Login
       run: |
         pip3 install -q requests

--- a/.github/workflows/helm_kubeflow_integration_test.yaml
+++ b/.github/workflows/helm_kubeflow_integration_test.yaml
@@ -1,0 +1,265 @@
+name: Test End-to-End Integration with Helm
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+    - master
+    # Runs only when a chart, a Helm install script, or this workflow changes,
+    # so the second full-platform job does not load every pull request. The
+    # in-place replacement of the Kustomize gate is a later, separate decision.
+    paths:
+    - common/*/helm/**
+    - applications/*/helm/**
+    - applications/*/*/helm/**
+    - experimental/helm/charts/**
+    - tests/*_helm_install.sh
+    - .github/workflows/helm_kubeflow_integration_test.yaml
+
+permissions:
+  contents: read
+  actions: read
+
+env:
+  KF_PROFILE: kubeflow-user-example-com
+
+jobs:
+  helm_kubeflow_integration_test:
+    name: Kubeflow Helm Installation and Testing
+    if: ${{ github.repository == 'kubeflow/community-distribution' }}
+    runs-on:
+      labels: oracle-vm-16cpu-64gb-x86-64
+      # labels: ubuntu-latest-16-cores
+    timeout-minutes: 45
+    steps:
+    - name: Checkout
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+    - name: Install Helm
+      uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
+      with:
+        version: v4.2.2
+
+    - name: Install KinD, Create KinD cluster and Install kustomize
+      run: ./tests/install_KinD_create_KinD_cluster_install_kustomize.sh
+
+    - name: Install Kubeflow Namespaces with Helm
+      run: ./tests/kubeflow_namespace_helm_install.sh
+
+    - name: Install Certificate Manager with Helm
+      run: ./tests/cert_manager_helm_install.sh
+
+    - name: Install Istio CNI
+      run: ./tests/istio-cni_install.sh
+
+    - name: Install OAuth2 Proxy with Helm
+      run: ./tests/oauth2-proxy_helm_install.sh
+
+    - name: Install Kubeflow Istio Resources
+      run: kustomize build common/istio/kubeflow-istio-resources/base | kubectl apply -f -
+
+    - name: Install Multi-Tenancy with Helm
+      run: ./tests/multi_tenancy_helm_install.sh
+
+    - name: Install Dex with Helm
+      run: ./tests/dex_helm_install.sh
+
+    - name: Install Dashboard with Helm
+      run: ./tests/dashboard_helm_install.sh
+
+    - name: Install Knative Serving
+      run: ./tests/knative_serving_install.sh
+
+    - name: Install Knative Eventing
+      run: ./tests/knative_eventing_install.sh
+
+    - name: Install KServe
+      run: ./tests/kserve_install.sh
+
+    - name: Install Pipelines with SeaweedFS
+      run: ./tests/pipelines_install.sh
+
+    - name: Create KF Profile
+      run: ./tests/kubeflow_profile_install.sh
+
+    - name: Install Notebooks v1 with Helm
+      run: ./tests/notebooks_helm_install.sh
+
+    - name: Install Katib with Helm
+      run: ./tests/katib_helm_install.sh
+
+    - name: Install Trainer
+      run: ./tests/trainer_install.sh
+
+    - name: Install Ray
+      run: |
+        cd experimental/ray/
+        kustomize build kuberay-operator/overlays/kubeflow | kubectl -n kubeflow apply --server-side -f -
+        kubectl -n kubeflow wait --for=condition=available --timeout=60s deploy/kuberay-operator
+
+
+    - name: Install Model Registry
+      run: ./tests/model_registry_install.sh
+
+    - name: Install Model Catalog
+      run: ./tests/model_catalog_install.sh
+
+    - name: Install Spark
+      run: chmod u+x tests/*.sh && ./tests/spark_install.sh
+
+    - name: Install Kubeflow Workspaces
+      run: ./tests/workspaces_install.sh
+
+    - name: Wait for All Pods to be Ready
+      run: kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout 90s --field-selector=status.phase!=Succeeded
+
+    - name: Port-forward the istio-ingress gateway
+      run: ./tests/port_forward_gateway.sh
+
+    #  name: Setup OAuth2 and Dex Credentials
+    #  run: chmod +x tests/oauth2_dex_credentials.sh && ./tests/oauth2_dex_credentials.sh
+
+    - name: Run Trainer Test
+      run: ./tests/trainer_test.sh "${KF_PROFILE}"
+
+    - name: Test Dex Login
+      run: |
+        pip3 install -q requests
+        python3 tests/dex_login_test.py
+        echo "Dex login test completed successfully."
+
+    - name: Verify Pipeline Integration
+      run: |
+        KF_PROFILE=kubeflow-user-example-com
+        if ! kubectl get secret mlpipeline-minio-artifact -n $KF_PROFILE > /dev/null 2>&1; then
+          echo "Error: Secret mlpipeline-minio-artifact not found in namespace $KF_PROFILE"
+          exit 1
+        fi
+        kubectl get secret mlpipeline-minio-artifact -n "$KF_PROFILE" -o json | jq -r '.data | keys[] as $k | "\($k): \(. | .[$k] | @base64d)"' | tr '\n' ' '
+
+    - name: Install lib2to3 for KFP V1 SDK with Python3.12 (lib2to3 has been removed from python 3.12)
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y python3-lib2to3
+
+    - name: V1 Pipeline Test
+      run: |
+        pip3 install "kfp>=1.8.24,<2.0.0"
+        TOKEN="$(kubectl -n $KF_PROFILE create token default-editor)"
+        python3 tests/pipeline_v1_test.py "${TOKEN}" "${KF_PROFILE}"
+
+    - name: V2 Pipeline Test
+      run: |
+        pip3 install -U "kfp>=2.17.0" kfp-kubernetes
+        TOKEN="$(kubectl -n $KF_PROFILE create token default-editor)"
+        python3 tests/pipeline_v2_test.py run_pipeline "${TOKEN}" "${KF_PROFILE}"
+
+    - name: Test Pipeline Access with Unauthorized Token
+      run: |
+        kubectl create namespace test-unauthorized
+        kubectl create serviceaccount test-unauthorized -n test-unauthorized
+        UNAUTHORIZED_TOKEN=$(kubectl -n test-unauthorized create token test-unauthorized)
+        python3 tests/pipeline_v2_test.py test_unauthorized_access "$UNAUTHORIZED_TOKEN" "${KF_PROFILE}"
+
+    - name: Test SeaweedFS Namespace Isolation
+      run: ./tests/swfs_namespace_isolation_test.sh
+
+    - name: Test Volumes Web Application API
+      run: ./tests/volumes_web_application_test.sh "${KF_PROFILE}"
+
+    - name: Apply PodDefault for Pipeline Access Token
+      run: sed "s/kubeflow-user-example-com/$KF_PROFILE/g" tests/poddefaults.access-ml-pipeline.kubeflow-user-example-com.yaml | kubectl apply -f -
+
+    - name: Create Test Notebook
+      run: |
+        sed "s/kubeflow-user-example-com/$KF_PROFILE/g" tests/notebook.test.kubeflow-user-example.com.yaml | kubectl apply -f -
+        kubectl wait --for=condition=Ready pod -l app=test -n $KF_PROFILE --timeout=180s
+
+    - name: Copy and execute the pipeline run script in KF Notebook
+      run: |
+        cp tests/pipeline_run_and_wait_kubeflow.py /tmp/run_pipeline_temp.py
+        sed -i "s/experiment_namespace = \"kubeflow-user-example-com\"/experiment_namespace = \"$KF_PROFILE\"/g" /tmp/run_pipeline_temp.py
+        sed -i 's/except Exception:/except Exception as e:/g' /tmp/run_pipeline_temp.py
+        sed -i 's/logger.info("Experiment not found, trying to create experiment.")/logger.info("Experiment not found, trying to create experiment. Error: " + str(e))/g' /tmp/run_pipeline_temp.py
+
+        kubectl -n $KF_PROFILE cp /tmp/run_pipeline_temp.py test-0:/home/jovyan/pipeline_run_and_wait_kubeflow.py
+
+        kubectl -n $KF_PROFILE exec test-0 -- python /home/jovyan/pipeline_run_and_wait_kubeflow.py
+
+    - name: Run Katib Test
+      run: ./tests/katib_test.sh "${KF_PROFILE}"
+
+    - name: Run KServe Test
+      run: ./tests/kserve_test.sh ${KF_PROFILE}
+
+    - name: Run Spark Test
+      run: chmod u+x tests/*.sh && ./tests/spark_test.sh "${KF_PROFILE}"
+
+    - name: Test Kubeflow Workspaces API
+      run: ./tests/workspaces_test.sh "${KF_PROFILE}"
+
+    - name: Run Ray Test
+      run: |
+        cd experimental/ray/
+        ./test.sh ${KF_PROFILE}
+
+    - name: Run Model Registry Tests
+      run: ./tests/model_registry_test.sh
+
+    - name: Run Model Catalog API Tests
+      run: ./tests/model_catalog_test.sh
+
+    - name: Apply Pod Security Standards Restricted
+      run: ./tests/PSS_enable.sh restricted
+
+    - name: Fail if there are resources in the "default" namespace
+      run: |
+        echo "==== Checking for resources in the default namespace ===="
+        DEFAULT_PODS=$(kubectl get pods -n default --no-headers --ignore-not-found 2>/dev/null | grep -v "^$" | wc -l)
+        if [ "${DEFAULT_PODS}" -gt 0 ]; then
+          echo "ERROR: Found ${DEFAULT_PODS} pods in the default namespace."
+          echo "No Kubeflow component should deploy to the default namespace."
+          echo ""
+          echo "==== Diagnostic dump ===="
+          kubectl get all -n default
+          echo ""
+          echo "==== Pod details ===="
+          kubectl get pods -n default -o wide
+          exit 1
+        fi
+        echo "PASSED: The default namespace does not contain pods."
+
+    - name: Verify Components
+      run: kubectl get pods --all-namespaces | grep -E '(Error|CrashLoopBackOff)' && exit 1 || true
+
+    - name: Install Metrics Server
+      run: ./tests/metrics-server_install.sh
+
+    - name: Check Pod Resource Usage
+      run: |
+        echo "==== Resource Usage Table ===="
+        pip3 install -q PyYAML
+        python3 tests/metrics-server_resource_table.py
+
+    - name: Collect Logs on Failure
+      if: failure()
+      # kubectl has no request timeout by default, so bound this step and
+      # let the upload below still run if the API server stops responding.
+      timeout-minutes: 5
+      run: |
+        mkdir -p logs
+        kubectl get all --all-namespaces > logs/resources.txt
+        kubectl get events --all-namespaces --sort-by=.metadata.creationTimestamp > logs/events.txt
+        for namespace in kubeflow kserve kubeflow-system istio-system cert-manager auth kubeflow-user-example-com; do
+            kubectl get namespace $namespace >/dev/null 2>&1 || continue
+            kubectl describe pods -n $namespace > logs/$namespace-pods.txt
+            for pod in $(kubectl get pods -n $namespace -o jsonpath='{.items[*].metadata.name}'); do
+                kubectl logs -n $namespace $pod --tail=100 > logs/$namespace-$pod.txt 2>&1 || true
+            done
+        done
+
+    - name: Upload Diagnostic Logs
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: kubeflow-test-logs
+        path: logs/

--- a/.github/workflows/helm_kubeflow_integration_test.yaml
+++ b/.github/workflows/helm_kubeflow_integration_test.yaml
@@ -4,7 +4,10 @@ on:
   # Runs only when a chart, a Helm installation script, or this workflow
   # changes, so the second full-platform job does not load every pull request
   # or push. The in-place replacement of the Kustomize gate is a later,
-  # separate decision.
+  # separate decision. The Katib chart is the only experimental chart this
+  # workflow installs; the other experimental charts are not exercised here
+  # and are replaced by co-located charts. The shared Knative Serving script
+  # carries a branch only this workflow runs (ISTIO_MANAGED_BY_HELM).
   push:
     branches:
     - master
@@ -12,8 +15,9 @@ on:
     - common/*/helm/**
     - applications/*/helm/**
     - applications/*/*/helm/**
-    - experimental/helm/charts/**
+    - experimental/helm/charts/katib/**
     - tests/*_helm_install.sh
+    - tests/knative_serving_install.sh
     - .github/workflows/helm_kubeflow_integration_test.yaml
   pull_request:
     branches:
@@ -22,8 +26,9 @@ on:
     - common/*/helm/**
     - applications/*/helm/**
     - applications/*/*/helm/**
-    - experimental/helm/charts/**
+    - experimental/helm/charts/katib/**
     - tests/*_helm_install.sh
+    - tests/knative_serving_install.sh
     - .github/workflows/helm_kubeflow_integration_test.yaml
 
 permissions:

--- a/.github/workflows/helm_kubeflow_integration_test.yaml
+++ b/.github/workflows/helm_kubeflow_integration_test.yaml
@@ -1,12 +1,23 @@
 name: Test End-to-End Integration with Helm
 on:
   workflow_dispatch:
+  # Runs only when a chart, a Helm installation script, or this workflow
+  # changes, so the second full-platform job does not load every pull request
+  # or push. The in-place replacement of the Kustomize gate is a later,
+  # separate decision.
+  push:
+    branches:
+    - master
+    paths:
+    - common/*/helm/**
+    - applications/*/helm/**
+    - applications/*/*/helm/**
+    - experimental/helm/charts/**
+    - tests/*_helm_install.sh
+    - .github/workflows/helm_kubeflow_integration_test.yaml
   pull_request:
     branches:
     - master
-    # Runs only when a chart, a Helm install script, or this workflow changes,
-    # so the second full-platform job does not load every pull request. The
-    # in-place replacement of the Kustomize gate is a later, separate decision.
     paths:
     - common/*/helm/**
     - applications/*/helm/**
@@ -48,14 +59,14 @@ jobs:
     - name: Install Certificate Manager with Helm
       run: ./tests/cert_manager_helm_install.sh
 
-    - name: Install Istio CNI
-      run: ./tests/istio-cni_install.sh
+    - name: Install Istio with Helm
+      run: ./tests/istio_helm_install.sh
 
     - name: Install OAuth2 Proxy with Helm
       run: ./tests/oauth2-proxy_helm_install.sh
 
-    - name: Install Kubeflow Istio Resources
-      run: kustomize build common/istio/kubeflow-istio-resources/base | kubectl apply -f -
+    - name: Install Kubeflow Istio Resources with Helm
+      run: ./tests/kubeflow_istio_resources_helm_install.sh
 
     - name: Install Multi-Tenancy with Helm
       run: ./tests/multi_tenancy_helm_install.sh
@@ -67,6 +78,10 @@ jobs:
       run: ./tests/dashboard_helm_install.sh
 
     - name: Install Knative Serving
+      # The istio release already owns the cluster-local gateway and the
+      # Kubeflow Istio resources, so the shared script skips its Istio applies.
+      env:
+        ISTIO_MANAGED_BY_HELM: "true"
       run: ./tests/knative_serving_install.sh
 
     - name: Install Knative Eventing

--- a/tests/cert_manager_helm_install.sh
+++ b/tests/cert_manager_helm_install.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Helm counterpart of tests/cert_manager_install.sh: install the base profile,
+# wait for the webhook, then upgrade to the kubeflow profile, mirroring the
+# base-then-overlay order of the Kustomize script.
+set -euxo pipefail
+echo "Installing cert-manager with Helm ..."
+helm repo add jetstack https://charts.jetstack.io || helm repo update jetstack
+helm dependency build common/cert-manager/helm
+helm install cert-manager common/cert-manager/helm \
+  --namespace cert-manager \
+  --values common/cert-manager/helm/ci/values-base.yaml \
+  --wait --timeout 5m
+helm upgrade cert-manager common/cert-manager/helm \
+  --namespace cert-manager \
+  --values common/cert-manager/helm/ci/values-kubeflow.yaml \
+  --wait --timeout 5m
+kubectl wait --for=jsonpath='{.subsets[0].addresses[0].targetRef.kind}'=Pod endpoints -l 'app in (cert-manager,webhook)' --timeout=180s -n cert-manager

--- a/tests/dashboard_helm_install.sh
+++ b/tests/dashboard_helm_install.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Helm counterpart of tests/dashboard_install.sh, proven equivalent to
+# applications/dashboard/overlays/istio by the kubeflow-dashboard scenario.
+set -euxo pipefail
+echo "Installing Kubeflow Dashboard with Helm ..."
+helm install kubeflow-dashboard applications/dashboard/helm \
+  --namespace kubeflow \
+  --values applications/dashboard/helm/ci/values-platform.yaml \
+  --wait --timeout 5m
+kubectl wait --for=condition=Established --timeout=60s crd/profiles.kubeflow.org
+kubectl wait --for=condition=Established --timeout=60s crd/poddefaults.kubeflow.org
+kubectl wait --for=condition=Ready pods -n kubeflow -l app.kubernetes.io/part-of=kubeflow-dashboard --timeout=60s

--- a/tests/dex_helm_install.sh
+++ b/tests/dex_helm_install.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Helm counterpart of tests/dex_install.sh, proven equivalent to
+# common/dex/overlays/oauth2-proxy by the dex comparison scenario. The ci
+# values carry the parity fixture credentials the end-to-end login test uses.
+set -euxo pipefail
+helm install dex common/dex/helm \
+  --namespace auth \
+  --values common/dex/helm/ci/values-oauth2-proxy.yaml \
+  --wait --timeout 5m
+kubectl wait --for=condition=Ready pods --all --timeout=180s -n auth

--- a/tests/istio_helm_install.sh
+++ b/tests/istio_helm_install.sh
@@ -38,10 +38,18 @@ for name in "${CUSTOM_RESOURCE_DEFINITION_NAMES[@]}"; do
   kubectl wait --for=condition=Established "crd/${name}" --timeout=120s
 done
 
+# Helm 4 applies server-side. Once istiod is ready, its validation controller
+# (field manager pilot-discovery) sets failurePolicy: Fail on
+# ValidatingWebhookConfiguration/istio-validator-istio-system, while the payload
+# ships Ignore so the webhook fails open until istiod answers. Every later
+# upgrade therefore conflicts on that field; --force-conflicts reapplies the
+# payload value and istiod flips it back within seconds, the same trade the
+# raw installers make with kubectl apply --server-side --force-conflicts.
 helm upgrade istio common/istio/helm \
   --namespace istio-system \
   --values common/istio/helm/ci/values-oauth2-proxy.yaml \
   --set namespaces.create=false \
+  --force-conflicts \
   --wait --timeout 5m
 
 echo "Waiting for all Istio Pods to become ready..."

--- a/tests/istio_helm_install.sh
+++ b/tests/istio_helm_install.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Helm counterpart of tests/istio-cni_install.sh, proven equivalent to
+# common/istio/istio-crds/base, istio-namespace/base and
+# istio-install/overlays/oauth2-proxy by the istio crds and oauth2-proxy
+# comparison scenarios.
+#
+# Two release revisions, as the chart README documents: the first renders only
+# the CustomResourceDefinitions, the second the Istio installation, because
+# Istio custom resources cannot be created before their definitions are
+# established. The comparison scenario values enable namespaces.create so the
+# Namespace is compared; here the kubeflow-namespaces chart already owns
+# Namespace/istio-system, so the flag is turned off on the command line.
+set -euxo pipefail
+echo "Installing Istio (with ExtAuthZ from oauth2-proxy) with Helm ..."
+helm install istio common/istio/helm \
+  --namespace istio-system \
+  --values common/istio/helm/ci/values-crds.yaml \
+  --wait --timeout 5m
+
+mapfile -t CUSTOM_RESOURCE_DEFINITION_NAMES < <(
+  helm get manifest istio --namespace istio-system |
+    awk '
+      $0 == "kind: CustomResourceDefinition" {
+        custom_resource_definition = 1
+        next
+      }
+      custom_resource_definition && /^  name: / {
+        print $2
+        custom_resource_definition = 0
+      }
+    '
+)
+if [[ "${#CUSTOM_RESOURCE_DEFINITION_NAMES[@]}" -eq 0 ]]; then
+  echo "No CustomResourceDefinition resources were found in the istio Helm release." >&2
+  exit 1
+fi
+for name in "${CUSTOM_RESOURCE_DEFINITION_NAMES[@]}"; do
+  kubectl wait --for=condition=Established "crd/${name}" --timeout=120s
+done
+
+helm upgrade istio common/istio/helm \
+  --namespace istio-system \
+  --values common/istio/helm/ci/values-oauth2-proxy.yaml \
+  --set namespaces.create=false \
+  --wait --timeout 5m
+
+echo "Waiting for all Istio Pods to become ready..."
+kubectl rollout status deployment/istiod -n istio-system --timeout=180s
+kubectl rollout status deployment/istio-ingressgateway -n istio-system --timeout=180s
+kubectl rollout status daemonset/istio-cni-node -n kube-system --timeout=180s
+kubectl wait --for=condition=Ready pods --all -n istio-system --timeout 180s
+kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout=180s '--field-selector=status.phase!=Succeeded'

--- a/tests/katib_helm_install.sh
+++ b/tests/katib_helm_install.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Helm counterpart of tests/katib_install.sh, proven equivalent to
+# applications/katib/upstream/installs/katib-with-kubeflow by the katib
+# with-kubeflow comparison scenario.
+set -euxo pipefail
+helm install katib experimental/helm/charts/katib \
+  --namespace kubeflow \
+  --values experimental/helm/charts/katib/ci/values-kubeflow.yaml \
+  --wait --timeout 5m
+kubectl wait --for=condition=Available deployment/katib-controller -n kubeflow --timeout=300s
+kubectl wait --for=condition=Available deployment/katib-mysql -n kubeflow --timeout=300s
+kubectl label namespace $KF_PROFILE katib.kubeflow.org/metrics-collector-injection=enabled --overwrite

--- a/tests/knative_serving_install.sh
+++ b/tests/knative_serving_install.sh
@@ -10,9 +10,16 @@ for ((i=1; i<=3; i++)); do
 done
 set -e
 
-kustomize build common/istio/cluster-local-gateway/overlays/m2m-auth | kubectl apply -f -
+# The Helm integration workflow installs the cluster-local gateway and the
+# Kubeflow Istio resources through the istio Helm release
+# (tests/kubeflow_istio_resources_helm_install.sh). A resource belongs to
+# exactly one owner, so that workflow sets ISTIO_MANAGED_BY_HELM=true and
+# skips these applies; the Kustomize gate leaves the variable unset.
+if [[ "${ISTIO_MANAGED_BY_HELM:-false}" != "true" ]]; then
+    kustomize build common/istio/cluster-local-gateway/overlays/m2m-auth | kubectl apply -f -
 
-kustomize build common/istio/kubeflow-istio-resources/base | kubectl apply -f -
+    kustomize build common/istio/kubeflow-istio-resources/base | kubectl apply -f -
+fi
 
 kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout=60s --field-selector=status.phase!=Succeeded
 kubectl wait --for=condition=Available deployment/activator -n knative-serving --timeout=10s

--- a/tests/kubeflow_istio_resources_helm_install.sh
+++ b/tests/kubeflow_istio_resources_helm_install.sh
@@ -12,9 +12,12 @@
 # cluster JWKS proxy, so this runs after tests/oauth2-proxy_helm_install.sh.
 set -euxo pipefail
 echo "Installing Kubeflow Istio resources and the cluster-local gateway with Helm ..."
+# --force-conflicts: istiod owns failurePolicy on the validating webhook; see
+# tests/istio_helm_install.sh.
 helm upgrade istio common/istio/helm \
   --namespace istio-system \
   --values common/istio/helm/ci/values-platform-full.yaml \
   --set namespaces.create=false \
+  --force-conflicts \
   --wait --timeout 5m
 kubectl rollout status deployment/cluster-local-gateway -n istio-system --timeout=180s

--- a/tests/kubeflow_istio_resources_helm_install.sh
+++ b/tests/kubeflow_istio_resources_helm_install.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Helm counterpart of the "Install Kubeflow Istio Resources" step and of the
+# two Istio applies inside tests/knative_serving_install.sh, proven equivalent
+# to common/istio/kubeflow-istio-resources/base and
+# common/istio/cluster-local-gateway/overlays/m2m-auth by the istio
+# platform-full comparison scenario.
+#
+# Third revision of the istio release created by tests/istio_helm_install.sh:
+# the platform-full values keep the oauth2-proxy profile and add the
+# cluster-local gateway with machine-to-machine authentication and the
+# Kubeflow Istio resources. The gateway's RequestAuthentication points at the
+# cluster JWKS proxy, so this runs after tests/oauth2-proxy_helm_install.sh.
+set -euxo pipefail
+echo "Installing Kubeflow Istio resources and the cluster-local gateway with Helm ..."
+helm upgrade istio common/istio/helm \
+  --namespace istio-system \
+  --values common/istio/helm/ci/values-platform-full.yaml \
+  --set namespaces.create=false \
+  --wait --timeout 5m
+kubectl rollout status deployment/cluster-local-gateway -n istio-system --timeout=180s

--- a/tests/kubeflow_namespace_helm_install.sh
+++ b/tests/kubeflow_namespace_helm_install.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Helm counterpart of the "Create Kubeflow Namespace" step: the
+# kubeflow-namespaces chart owns every platform namespace and the network
+# policies, proven equivalent to common/kubeflow-namespace/base by
+# tests/run_helm_kustomize_comparison.py kubeflow-namespaces.
+set -euxo pipefail
+helm install kubeflow-namespaces common/kubeflow-namespace/helm \
+  --namespace default \
+  --values common/kubeflow-namespace/helm/ci/values-default.yaml \
+  --wait --timeout 5m

--- a/tests/kubeflow_namespace_helm_install.sh
+++ b/tests/kubeflow_namespace_helm_install.sh
@@ -3,8 +3,31 @@
 # kubeflow-namespaces chart owns every platform namespace and the network
 # policies, proven equivalent to common/kubeflow-namespace/base by
 # tests/run_helm_kustomize_comparison.py kubeflow-namespaces.
+#
+# Two phases: the first release revision renders only the Namespace objects,
+# the second adds the NetworkPolicies. In one revision Helm pre-creates the
+# namespaces its NetworkPolicies reference, and on a fast runner that bare
+# namespace wins the race against the chart's own labeled Namespace manifest,
+# leaving kubeflow-system without istio-injection and Pod Security labels.
 set -euxo pipefail
 helm install kubeflow-namespaces common/kubeflow-namespace/helm \
   --namespace default \
   --values common/kubeflow-namespace/helm/ci/values-default.yaml \
+  --set networkPolicies.enabled=false \
   --wait --timeout 5m
+helm upgrade kubeflow-namespaces common/kubeflow-namespace/helm \
+  --namespace default \
+  --values common/kubeflow-namespace/helm/ci/values-default.yaml \
+  --wait --timeout 5m
+
+# Fail here, not twenty minutes later at the first webhook call, if a
+# namespace ever comes up without its labels again.
+for namespace in kubeflow kubeflow-system; do
+  labels=$(kubectl get namespace "$namespace" -o jsonpath='{.metadata.labels}')
+  for label in istio-injection pod-security.kubernetes.io/enforce; do
+    echo "$labels" | grep -q "$label" || {
+      echo "ERROR: namespace $namespace is missing the $label label: $labels"
+      exit 1
+    }
+  done
+done

--- a/tests/multi_tenancy_helm_install.sh
+++ b/tests/multi_tenancy_helm_install.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Helm counterpart of tests/multi_tenancy_install.sh, proven equivalent to
+# common/kubeflow-roles/base by the kubeflow-platform comparison scenario.
+set -euxo pipefail
+echo "Installing Multitenancy Kubeflow Roles with Helm"
+# kubeflow-system stores only the release metadata; no chart renders it.
+helm install kubeflow-platform common/kubeflow-roles/helm \
+  --namespace kubeflow-system \
+  --create-namespace \
+  --values common/kubeflow-roles/helm/ci/values-default.yaml \
+  --wait --timeout 5m

--- a/tests/multi_tenancy_helm_install.sh
+++ b/tests/multi_tenancy_helm_install.sh
@@ -3,9 +3,9 @@
 # common/kubeflow-roles/base by the kubeflow-platform comparison scenario.
 set -euxo pipefail
 echo "Installing Multitenancy Kubeflow Roles with Helm"
-# kubeflow-system stores only the release metadata; no chart renders it.
+# kubeflow-system already exists: the kubeflow-namespaces chart renders it
+# with its labels. Creating it here would mask a broken foundation install.
 helm install kubeflow-platform common/kubeflow-roles/helm \
   --namespace kubeflow-system \
-  --create-namespace \
   --values common/kubeflow-roles/helm/ci/values-default.yaml \
   --wait --timeout 5m

--- a/tests/multi_tenancy_helm_install.sh
+++ b/tests/multi_tenancy_helm_install.sh
@@ -4,7 +4,7 @@
 set -euxo pipefail
 echo "Installing Multitenancy Kubeflow Roles with Helm"
 # kubeflow-system already exists: the kubeflow-namespaces chart renders it
-# with its labels. Creating it here would mask a broken foundation install.
+# with its labels. Creating it here would mask a broken foundation installation.
 helm install kubeflow-platform common/kubeflow-roles/helm \
   --namespace kubeflow-system \
   --values common/kubeflow-roles/helm/ci/values-default.yaml \

--- a/tests/notebooks_helm_install.sh
+++ b/tests/notebooks_helm_install.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Helm counterpart of tests/notebooks_install.sh, proven equivalent to
+# applications/notebooks-v1/overlays/istio by the kubeflow-notebooks scenario.
+set -euxo pipefail
+echo "Installing Kubeflow Notebooks v1 with Helm ..."
+helm install kubeflow-notebooks applications/notebooks-v1/helm \
+  --namespace kubeflow \
+  --values applications/notebooks-v1/helm/ci/values-platform.yaml \
+  --wait --timeout 5m

--- a/tests/oauth2-proxy_helm_install.sh
+++ b/tests/oauth2-proxy_helm_install.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Helm counterpart of tests/oauth2-proxy_install.sh, proven equivalent to
+# common/oauth2-proxy/overlays/m2m-dex-and-kind by the comparison scenario.
+set -euxo pipefail
+echo "Installing oauth2-proxy with Helm..."
+helm install oauth2-proxy common/oauth2-proxy/helm \
+  --namespace oauth2-proxy \
+  --values common/oauth2-proxy/helm/ci/values-m2m-dex-and-kind.yaml \
+  --wait --timeout 5m
+kubectl wait --for=condition=Ready pod -l 'app.kubernetes.io/name=oauth2-proxy' --timeout=180s -n oauth2-proxy
+kubectl wait --for=condition=Ready pod -l 'app.kubernetes.io/name=cluster-jwks-proxy' --timeout=180s -n istio-system


### PR DESCRIPTION
## What this does

Implements the mentor's direction for Helm integration testing: reuse the existing end-to-end workflow and replace the Kustomize installation steps with Helm installations where charts exist. `helm_kubeflow_integration_test.yaml` is a clone of `full_kubeflow_integration_test.yaml` with **only the installation steps changed** — the entire test suite (`dex_login_test.py`, the V1 and V2 pipeline runs, the unauthorized-token check, Katib, KServe, Spark, notebook execution, restricted Pod Security Standards) runs unchanged. The comparison harness already proves the rendered manifests are equivalent; this workflow proves the installation path.

## Installation steps swapped to Helm

| step | script | chart | values |
| --- | --- | --- | --- |
| Kubeflow Namespaces | `tests/kubeflow_namespace_helm_install.sh` | `common/kubeflow-namespace/helm` | `ci/values-default.yaml`, namespaces first and network policies by upgrade |
| Multi-Tenancy | `tests/multi_tenancy_helm_install.sh` | `common/kubeflow-roles/helm` | `ci/values-default.yaml` |
| Certificate Manager | `tests/cert_manager_helm_install.sh` | `common/cert-manager/helm` | `ci/values-base.yaml` then `ci/values-kubeflow.yaml`, mirroring the base-then-overlay order |
| Istio | `tests/istio_helm_install.sh` | `common/istio/helm` | `ci/values-crds.yaml`, then `ci/values-oauth2-proxy.yaml` after every CustomResourceDefinition is established |
| Kubeflow Istio Resources | `tests/kubeflow_istio_resources_helm_install.sh` | `common/istio/helm` | `ci/values-platform-full.yaml`: the cluster-local gateway with machine-to-machine authentication ([#3567](https://github.com/kubeflow/community-distribution/pull/3567)) and the Kubeflow Istio resources, as a third revision of the same release |
| Dex | `tests/dex_helm_install.sh` | `common/dex/helm` | `ci/values-oauth2-proxy.yaml` |
| OAuth2 Proxy | `tests/oauth2-proxy_helm_install.sh` | `common/oauth2-proxy/helm` | `ci/values-m2m-dex-and-kind.yaml` |
| Dashboard | `tests/dashboard_helm_install.sh` | `applications/dashboard/helm` | `ci/values-platform.yaml` |
| Notebooks v1 | `tests/notebooks_helm_install.sh` | `applications/notebooks-v1/helm` | `ci/values-platform.yaml` |
| Katib | `tests/katib_helm_install.sh` | `experimental/helm/charts/katib` | `ci/values-kubeflow.yaml` |

Every installation uses the ci values file of that chart's comparison scenario, so the installed manifests are exactly the ones `tests/run_helm_kustomize_comparison.py` proves equivalent to the Kustomize target the original step applied — including the parity fixture credentials the login test depends on. The Istio steps pass `--set namespaces.create=false` on top of the scenario values because the `kubeflow-namespaces` chart already owns `Namespace/istio-system`, exactly as the chart README documents.

Helm is the single Istio owner in this workflow: `tests/knative_serving_install.sh` skips its two raw Istio applies (cluster-local gateway, Kubeflow Istio resources) when `ISTIO_MANAGED_BY_HELM=true`, which only this workflow sets. The Kustomize gate is unchanged. The cluster-local gateway therefore arrives before Knative Serving instead of after it; the gateway deployment does not depend on Knative and its `RequestAuthentication` resolves the cluster JWKS proxy lazily, so this run is the proof.

## Growth model

A component's Helm installation step joins this workflow **in the pull request that adds its chart** — the same ownership model as `ci/comparison.yaml`. Every merged chart under `common/` and `applications/`, plus the Katib chart, is installed with Helm here; the experimental `kserve-ui` and `hub` charts are not used and are replaced by co-located charts. The Pipelines chart ([#3552](https://github.com/kubeflow/community-distribution/pull/3552), which already carries `tests/pipelines_helm_install.sh`) and the Spark Operator chart ([#3575](https://github.com/kubeflow/community-distribution/pull/3575)) each add their one-step swap once this merges. When this workflow has run stably alongside the Kustomize gate, replacing `full_kubeflow_integration_test.yaml` in place is a small, separately approved follow-up.

## Triggers

`workflow_dispatch`, plus `push` to `master` and `pull_request`, both filtered to the chart paths under `common/` and `applications/`, the Katib chart, the Helm installation scripts, `tests/knative_serving_install.sh` (its `ISTIO_MANAGED_BY_HELM` branch runs only here), and this workflow file — so the second full-platform job does not load every pull request or push while it is being proven.

## Verification

- Every `helm template <release> <chart> --namespace <n> --values <ci values>` renders under Helm 4.2.2, including the three Istio revisions with `namespaces.create=false` (no `Namespace` rendered; the four machine-to-machine gateway objects rendered).
- `bash -n` and `shellcheck` on every script; the workflow parses and passes `yamllint`.
- The first run of the full Istio ownership failed on the third Istio revision with `conflict with "pilot-discovery" ... .webhooks[name="rev.validation.istio.io"].failurePolicy` ([job 102251723172](https://github.com/kubeflow/community-distribution/actions/runs/34282926805/job/102251723172)): istiod sets `failurePolicy: Fail` on its validating webhook once ready, the payload ships `Ignore`, and Helm 4 server-side apply conflicts on every later upgrade. The Istio upgrades now pass `--force-conflicts`, the same trade the raw installers make with `kubectl apply --server-side --force-conflicts`; the chart README documents it in the Istio follow-up pull request.
- The real test is this pull request's own run of the new workflow.
