### PR TITLE
Update kubeflow/notebooks manifests to v2.0.0-beta.1

### DIFF
--- a/applications/workspaces/upstream/backend/base/kustomization.yaml
+++ b/applications/workspaces/upstream/backend/base/kustomization.yaml
@@ -18,4 +18,4 @@ labels:
 images:
 - name: workspaces-backend
   newName: ghcr.io/kubeflow/notebooks/workspaces-backend
-  newTag: v2.0.0-beta.0
+  newTag: v2.0.0-beta.1

--- a/applications/workspaces/upstream/controller/base/crd/kubeflow.org_workspacekinds.yaml
+++ b/applications/workspaces/upstream/controller/base/crd/kubeflow.org_workspacekinds.yaml
@@ -531,7 +531,7 @@ spec:
                                  precedence and `last_activity` is totally ignored (the probe does not fail).
                                  The fields are evaluated to update the Workspace status field `status.activity.lastActivity` as follows:
                                    - If `has_activity` is explicitly set to `true` (or if the JSON file is empty/omitted): The Workspace is treated as active, and `status.activity.lastActivity` is updated to the probe completion time (ignoring `last_activity`).
-                                   - If `has_activity` is explicitly set to `false`: The Workspace is treated as inactive, and the existing `status.activity.lastActivity` timestamp is preserved (unchanged, ignoring `last_activity`).
+                                   - If `has_activity` is explicitly set to `false`: The Workspace is treated as inactive, and the existing `status.activity.lastActivity` timestamp is preserved (unchanged, ignoring `last_activity`). If `status.activity.lastActivity` was not previously set (0), it is initialized to `status.lastRunningTime` to treat the Workspace as inactive since startup.
                                    - If `last_activity` (ISO 8601 string) is provided (and `has_activity` is omitted): The Workspace is treated as inactive, and `status.activity.lastActivity` is updated to the `last_activity` timestamp.
                             maxLength: 2048
                             minLength: 1
@@ -642,7 +642,6 @@ spec:
                           procMount denotes the type of proc mount to use for the containers.
                           The default value is Default which uses the container runtime defaults for
                           readonly paths and masked paths.
-                          This requires the ProcMountType feature flag to be enabled.
                           Note that this field cannot be set when spec.os.name is windows.
                         type: string
                       readOnlyRootFilesystem:
@@ -774,8 +773,9 @@ spec:
                         in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
                           type: string
                         value:
                           description: |-
@@ -831,6 +831,43 @@ spec:
                                   type: string
                               required:
                               - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -967,6 +1004,8 @@ spec:
                           description: |-
                             awsElasticBlockStore represents an AWS Disk resource that is attached to a
                             kubelet's host machine and then exposed to the pod.
+                            Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
+                            awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
                             More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                           properties:
                             fsType:
@@ -998,8 +1037,10 @@ spec:
                           - volumeID
                           type: object
                         azureDisk:
-                          description: azureDisk represents an Azure Data Disk mount
-                            on the host and bind mount to the pod.
+                          description: |-
+                            azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                            Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
+                            are redirected to the disk.csi.azure.com CSI driver.
                           properties:
                             cachingMode:
                               description: 'cachingMode is the Host Caching mode:
@@ -1038,8 +1079,10 @@ spec:
                           - diskURI
                           type: object
                         azureFile:
-                          description: azureFile represents an Azure File Service
-                            mount on the host and bind mount to the pod.
+                          description: |-
+                            azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                            Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
+                            are redirected to the file.csi.azure.com CSI driver.
                           properties:
                             readOnly:
                               description: |-
@@ -1058,8 +1101,9 @@ spec:
                           - shareName
                           type: object
                         cephfs:
-                          description: cephFS represents a Ceph FS mount on the host
-                            that shares a pod's lifetime
+                          description: |-
+                            cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
+                            Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
                           properties:
                             monitors:
                               description: |-
@@ -1111,6 +1155,8 @@ spec:
                         cinder:
                           description: |-
                             cinder represents a cinder volume attached and mounted on kubelets host machine.
+                            Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
+                            are redirected to the cinder.csi.openstack.org CSI driver.
                             More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                           properties:
                             fsType:
@@ -1222,7 +1268,7 @@ spec:
                         csi:
                           description: csi (Container Storage Interface) represents
                             ephemeral storage that is handled by certain external
-                            CSI drivers (Beta feature).
+                            CSI drivers.
                           properties:
                             driver:
                               description: |-
@@ -1537,7 +1583,7 @@ spec:
                                     resources:
                                       description: |-
                                         resources represents the minimum resources the volume should have.
-                                        If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                        Users are allowed to specify resource requirements
                                         that are lower than previous value but must still be higher than capacity recorded in the
                                         status field of the claim.
                                         More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -1625,15 +1671,13 @@ spec:
                                         volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                         If specified, the CSI driver will create or update the volume with the attributes defined
                                         in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                        it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                        will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                        If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                        will be set by the persistentvolume controller if it exists.
+                                        it can be changed after the claim is created. An empty string or nil value indicates that no
+                                        VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                        this field can be reset to its previous value (including nil) to cancel the modification.
                                         If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                         set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                         exists.
                                         More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                        (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                       type: string
                                     volumeMode:
                                       description: |-
@@ -1689,6 +1733,7 @@ spec:
                           description: |-
                             flexVolume represents a generic volume resource that is
                             provisioned/attached using an exec based plugin.
+                            Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
                           properties:
                             driver:
                               description: driver is the name of the driver to use
@@ -1734,9 +1779,9 @@ spec:
                           - driver
                           type: object
                         flocker:
-                          description: flocker represents a Flocker volume attached
-                            to a kubelet's host machine. This depends on the Flocker
-                            control service being running
+                          description: |-
+                            flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
+                            Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
                           properties:
                             datasetName:
                               description: |-
@@ -1752,6 +1797,8 @@ spec:
                           description: |-
                             gcePersistentDisk represents a GCE Disk resource that is attached to a
                             kubelet's host machine and then exposed to the pod.
+                            Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
+                            gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
                             More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                           properties:
                             fsType:
@@ -1787,7 +1834,7 @@ spec:
                         gitRepo:
                           description: |-
                             gitRepo represents a git repository at a particular revision.
-                            DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                            Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
                             EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
                             into the Pod's container.
                           properties:
@@ -1811,12 +1858,11 @@ spec:
                         glusterfs:
                           description: |-
                             glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md
+                            Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
                           properties:
                             endpoints:
-                              description: |-
-                                endpoints is the endpoint name that details Glusterfs topology.
-                                More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                              description: endpoints is the endpoint name that details
+                                Glusterfs topology.
                               type: string
                             path:
                               description: |-
@@ -1869,8 +1915,8 @@ spec:
                             A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                             The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                             The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                            The volume will be mounted read-only (ro) and non-executable files (noexec).
-                            Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).
+                            The volume will be mounted read-only (ro).
+                            Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                             The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                           properties:
                             pullPolicy:
@@ -1895,7 +1941,7 @@ spec:
                           description: |-
                             iscsi represents an ISCSI Disk resource that is attached to a
                             kubelet's host machine and then exposed to the pod.
-                            More info: https://examples.k8s.io/volumes/iscsi/README.md
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                           properties:
                             chapAuthDiscovery:
                               description: chapAuthDiscovery defines whether support
@@ -2020,9 +2066,9 @@ spec:
                           - claimName
                           type: object
                         photonPersistentDisk:
-                          description: photonPersistentDisk represents a PhotonController
-                            persistent disk attached and mounted on kubelets host
-                            machine
+                          description: |-
+                            photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
+                            Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
                           properties:
                             fsType:
                               description: |-
@@ -2038,8 +2084,10 @@ spec:
                           - pdID
                           type: object
                         portworxVolume:
-                          description: portworxVolume represents a portworx volume
-                            attached and mounted on kubelets host machine
+                          description: |-
+                            portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
+                            Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
+                            are redirected to the pxd.portworx.com CSI driver.
                           properties:
                             fsType:
                               description: |-
@@ -2314,6 +2362,129 @@ spec:
                                         type: array
                                         x-kubernetes-list-type: atomic
                                     type: object
+                                  podCertificate:
+                                    description: |-
+                                      Projects an auto-rotating credential bundle (private key and certificate
+                                      chain) that the pod can use either as a TLS client or server.
+
+                                      Kubelet generates a private key and uses it to send a
+                                      PodCertificateRequest to the named signer.  Once the signer approves the
+                                      request and issues a certificate chain, Kubelet writes the key and
+                                      certificate chain to the pod filesystem.  The pod does not start until
+                                      certificates have been issued for each podCertificate projected volume
+                                      source in its spec.
+
+                                      Kubelet will begin trying to rotate the certificate at the time indicated
+                                      by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                      timestamp.
+
+                                      Kubelet can write a single file, indicated by the credentialBundlePath
+                                      field, or separate files, indicated by the keyPath and
+                                      certificateChainPath fields.
+
+                                      The credential bundle is a single file in PEM format.  The first PEM
+                                      entry is the private key (in PKCS#8 format), and the remaining PEM
+                                      entries are the certificate chain issued by the signer (typically,
+                                      signers will return their certificate chain in leaf-to-root order).
+
+                                      Prefer using the credential bundle format, since your application code
+                                      can read it atomically.  If you use keyPath and certificateChainPath,
+                                      your application must make two separate file reads. If these coincide
+                                      with a certificate rotation, it is possible that the private key and leaf
+                                      certificate you read may not correspond to each other.  Your application
+                                      will need to check for this condition, and re-read until they are
+                                      consistent.
+
+                                      The named signer controls chooses the format of the certificate it
+                                      issues; consult the signer implementation's documentation to learn how to
+                                      use the certificates it issues.
+                                    properties:
+                                      certificateChainPath:
+                                        description: |-
+                                          Write the certificate chain at this path in the projected volume.
+
+                                          Most applications should use credentialBundlePath.  When using keyPath
+                                          and certificateChainPath, your application needs to check that the key
+                                          and leaf certificate are consistent, because it is possible to read the
+                                          files mid-rotation.
+                                        type: string
+                                      credentialBundlePath:
+                                        description: |-
+                                          Write the credential bundle at this path in the projected volume.
+
+                                          The credential bundle is a single file that contains multiple PEM blocks.
+                                          The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                          key.
+
+                                          The remaining blocks are CERTIFICATE blocks, containing the issued
+                                          certificate chain from the signer (leaf and any intermediates).
+
+                                          Using credentialBundlePath lets your Pod's application code make a single
+                                          atomic read that retrieves a consistent key and certificate chain.  If you
+                                          project them to separate files, your application code will need to
+                                          additionally check that the leaf certificate was issued to the key.
+                                        type: string
+                                      keyPath:
+                                        description: |-
+                                          Write the key at this path in the projected volume.
+
+                                          Most applications should use credentialBundlePath.  When using keyPath
+                                          and certificateChainPath, your application needs to check that the key
+                                          and leaf certificate are consistent, because it is possible to read the
+                                          files mid-rotation.
+                                        type: string
+                                      keyType:
+                                        description: |-
+                                          The type of keypair Kubelet will generate for the pod.
+
+                                          Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                          "ECDSAP521", and "ED25519".
+                                        type: string
+                                      maxExpirationSeconds:
+                                        description: |-
+                                          maxExpirationSeconds is the maximum lifetime permitted for the
+                                          certificate.
+
+                                          Kubelet copies this value verbatim into the PodCertificateRequests it
+                                          generates for this projection.
+
+                                          If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                          will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                          value is 7862400 (91 days).
+
+                                          The signer implementation is then free to issue a certificate with any
+                                          lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                          seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                          `kubernetes.io` signers will never issue certificates with a lifetime
+                                          longer than 24 hours.
+                                        format: int32
+                                        type: integer
+                                      signerName:
+                                        description: Kubelet's generated CSRs will
+                                          be addressed to this signer.
+                                        type: string
+                                      userAnnotations:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          userAnnotations allow pod authors to pass additional information to
+                                          the signer implementation.  Kubernetes does not restrict or validate this
+                                          metadata in any way.
+
+                                          These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                          the PodCertificateRequest objects that Kubelet creates.
+
+                                          Entries are subject to the same validation as object metadata annotations,
+                                          with the addition that all keys must be domain-prefixed. No restrictions
+                                          are placed on values, except an overall size limitation on the entire field.
+
+                                          Signers should document the keys and values they support. Signers should
+                                          deny requests that contain keys they do not recognize.
+                                        type: object
+                                    required:
+                                    - keyType
+                                    - signerName
+                                    type: object
                                   secret:
                                     description: secret information about the secret
                                       data to project
@@ -2406,8 +2577,9 @@ spec:
                               x-kubernetes-list-type: atomic
                           type: object
                         quobyte:
-                          description: quobyte represents a Quobyte mount on the host
-                            that shares a pod's lifetime
+                          description: |-
+                            quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
+                            Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
                           properties:
                             group:
                               description: |-
@@ -2446,7 +2618,7 @@ spec:
                         rbd:
                           description: |-
                             rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md
+                            Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
                           properties:
                             fsType:
                               description: |-
@@ -2518,8 +2690,9 @@ spec:
                           - monitors
                           type: object
                         scaleIO:
-                          description: scaleIO represents a ScaleIO persistent volume
-                            attached and mounted on Kubernetes nodes.
+                          description: |-
+                            scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                            Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
                           properties:
                             fsType:
                               default: xfs
@@ -2652,8 +2825,9 @@ spec:
                               type: string
                           type: object
                         storageos:
-                          description: storageOS represents a StorageOS volume attached
-                            and mounted on Kubernetes nodes.
+                          description: |-
+                            storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                            Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
                           properties:
                             fsType:
                               description: |-
@@ -2698,8 +2872,10 @@ spec:
                               type: string
                           type: object
                         vsphereVolume:
-                          description: vsphereVolume represents a vSphere volume attached
-                            and mounted on kubelets host machine
+                          description: |-
+                            vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
+                            Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
+                            are redirected to the csi.vsphere.vmware.com CSI driver.
                           properties:
                             fsType:
                               description: |-
@@ -3326,7 +3502,6 @@ spec:
                                                           pod labels will be ignored. The default value is empty.
                                                           The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                           Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                         items:
                                                           type: string
                                                         type: array
@@ -3341,7 +3516,6 @@ spec:
                                                           pod labels will be ignored. The default value is empty.
                                                           The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                           Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                         items:
                                                           type: string
                                                         type: array
@@ -3514,7 +3688,6 @@ spec:
                                                       pod labels will be ignored. The default value is empty.
                                                       The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                       Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                     items:
                                                       type: string
                                                     type: array
@@ -3529,7 +3702,6 @@ spec:
                                                       pod labels will be ignored. The default value is empty.
                                                       The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                       Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                     items:
                                                       type: string
                                                     type: array
@@ -3627,8 +3799,8 @@ spec:
                                                 most preferred is the one with the greatest sum of weights, i.e.
                                                 for each node that meets all of the scheduling requirements (resource
                                                 request, requiredDuringScheduling anti-affinity expressions, etc.),
-                                                compute a sum by iterating through the elements of this field and adding
-                                                "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                compute a sum by iterating through the elements of this field and subtracting
+                                                "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
                                                 node(s) with the highest sum are the most preferred.
                                               items:
                                                 description: The weights of all of
@@ -3703,7 +3875,6 @@ spec:
                                                           pod labels will be ignored. The default value is empty.
                                                           The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                           Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                         items:
                                                           type: string
                                                         type: array
@@ -3718,7 +3889,6 @@ spec:
                                                           pod labels will be ignored. The default value is empty.
                                                           The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                           Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                         items:
                                                           type: string
                                                         type: array
@@ -3891,7 +4061,6 @@ spec:
                                                       pod labels will be ignored. The default value is empty.
                                                       The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                       Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                     items:
                                                       type: string
                                                     type: array
@@ -3906,7 +4075,6 @@ spec:
                                                       pod labels will be ignored. The default value is empty.
                                                       The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                       Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                     items:
                                                       type: string
                                                     type: array
@@ -4005,7 +4173,7 @@ spec:
                                             Claims lists the names of resources, defined in spec.resourceClaims,
                                             that are used by this container.
 
-                                            This is an alpha field and requires enabling the
+                                            This field depends on the
                                             DynamicResourceAllocation feature gate.
 
                                             This field is immutable. It can only be set for containers.
@@ -4057,6 +4225,16 @@ spec:
                                             More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                           type: object
                                       type: object
+                                    schedulerName:
+                                      description: |-
+                                        the name of the scheduler to use for the pod
+                                         - this takes precedence over the `schedulerName` of the pod template
+                                         - set this to "default-scheduler" to have this pod config use the
+                                           default Kubernetes scheduler, even if the pod template sets another one
+                                         - no character/length validation, matching Kubernetes which applies none
+                                           to PodSpec.SchedulerName; an empty value means the default scheduler
+                                      example: volcano
+                                      type: string
                                     tolerations:
                                       description: toleration configs for the pod
                                       items:
@@ -4077,9 +4255,10 @@ spec:
                                           operator:
                                             description: |-
                                               Operator represents a key's relationship to the value.
-                                              Valid operators are Exists and Equal. Defaults to Equal.
+                                              Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                                               Exists is equivalent to wildcard for value, so that a pod can
                                               tolerate all taints of a particular category.
+                                              Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                                             type: string
                                           tolerationSeconds:
                                             description: |-
@@ -4226,7 +4405,8 @@ spec:
                         description: the liveness probe for the main container
                         properties:
                           exec:
-                            description: Exec specifies the action to take.
+                            description: Exec specifies a command to execute in the
+                              container.
                             properties:
                               command:
                                 description: |-
@@ -4247,8 +4427,7 @@ spec:
                             format: int32
                             type: integer
                           grpc:
-                            description: GRPC specifies an action involving a GRPC
-                              port.
+                            description: GRPC specifies a GRPC HealthCheckRequest.
                             properties:
                               port:
                                 description: Port number of the gRPC service. Number
@@ -4267,7 +4446,8 @@ spec:
                             - port
                             type: object
                           httpGet:
-                            description: HTTPGet specifies the http request to perform.
+                            description: HTTPGet specifies an HTTP GET request to
+                              perform.
                             properties:
                               host:
                                 description: |-
@@ -4334,8 +4514,8 @@ spec:
                             format: int32
                             type: integer
                           tcpSocket:
-                            description: TCPSocket specifies an action involving a
-                              TCP port.
+                            description: TCPSocket specifies a connection to a TCP
+                              port.
                             properties:
                               host:
                                 description: 'Optional: Host name to connect to, defaults
@@ -4379,7 +4559,8 @@ spec:
                         description: the readiness probe for the main container
                         properties:
                           exec:
-                            description: Exec specifies the action to take.
+                            description: Exec specifies a command to execute in the
+                              container.
                             properties:
                               command:
                                 description: |-
@@ -4400,8 +4581,7 @@ spec:
                             format: int32
                             type: integer
                           grpc:
-                            description: GRPC specifies an action involving a GRPC
-                              port.
+                            description: GRPC specifies a GRPC HealthCheckRequest.
                             properties:
                               port:
                                 description: Port number of the gRPC service. Number
@@ -4420,7 +4600,8 @@ spec:
                             - port
                             type: object
                           httpGet:
-                            description: HTTPGet specifies the http request to perform.
+                            description: HTTPGet specifies an HTTP GET request to
+                              perform.
                             properties:
                               host:
                                 description: |-
@@ -4487,8 +4668,8 @@ spec:
                             format: int32
                             type: integer
                           tcpSocket:
-                            description: TCPSocket specifies an action involving a
-                              TCP port.
+                            description: TCPSocket specifies a connection to a TCP
+                              port.
                             properties:
                               host:
                                 description: 'Optional: Host name to connect to, defaults
@@ -4532,7 +4713,8 @@ spec:
                         description: the startup probe for the main container
                         properties:
                           exec:
-                            description: Exec specifies the action to take.
+                            description: Exec specifies a command to execute in the
+                              container.
                             properties:
                               command:
                                 description: |-
@@ -4553,8 +4735,7 @@ spec:
                             format: int32
                             type: integer
                           grpc:
-                            description: GRPC specifies an action involving a GRPC
-                              port.
+                            description: GRPC specifies a GRPC HealthCheckRequest.
                             properties:
                               port:
                                 description: Port number of the gRPC service. Number
@@ -4573,7 +4754,8 @@ spec:
                             - port
                             type: object
                           httpGet:
-                            description: HTTPGet specifies the http request to perform.
+                            description: HTTPGet specifies an HTTP GET request to
+                              perform.
                             properties:
                               host:
                                 description: |-
@@ -4640,8 +4822,8 @@ spec:
                             format: int32
                             type: integer
                           tcpSocket:
-                            description: TCPSocket specifies an action involving a
-                              TCP port.
+                            description: TCPSocket specifies a connection to a TCP
+                              port.
                             properties:
                               host:
                                 description: 'Optional: Host name to connect to, defaults
@@ -4682,6 +4864,17 @@ spec:
                             type: integer
                         type: object
                     type: object
+                  schedulerName:
+                    description: |-
+                      the name of the scheduler to use for Workspace Pods (MUTABLE)
+                       - this is the default for all Workspaces of this WorkspaceKind, it may be
+                         overridden by the `schedulerName` of a pod config value
+                       - if not set here, or on the pod config value, the Kubernetes API server
+                         will default to the "default-scheduler"
+                       - no character/length validation, matching Kubernetes which applies none
+                         to PodSpec.SchedulerName; an empty value means the default scheduler
+                    example: default-scheduler
+                    type: string
                   securityContext:
                     description: security context for Workspace Pods (MUTABLE)
                     properties:
@@ -4761,6 +4954,32 @@ spec:
                           Note that this field cannot be set when spec.os.name is windows.
                         format: int64
                         type: integer
+                      seLinuxChangePolicy:
+                        description: |-
+                          seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
+                          It has no effect on nodes that do not support SELinux or to volumes does not support SELinux.
+                          Valid values are "MountOption" and "Recursive".
+
+                          "Recursive" means relabeling of all files on all Pod volumes by the container runtime.
+                          This may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.
+
+                          "MountOption" mounts all eligible Pod volumes with `-o context` mount option.
+                          This requires all Pods that share the same volume to use the same SELinux label.
+                          It is not possible to share the same volume among privileged and unprivileged Pods.
+                          Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
+                          whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
+                          CSIDriver instance. Other volumes are always re-labelled recursively.
+                          "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
+
+                          If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
+                          If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
+                          and "Recursive" for all other volumes.
+
+                          This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
+
+                          All Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: string
                       seLinuxOptions:
                         description: |-
                           The SELinux context to be applied to all containers.
@@ -4931,6 +5150,22 @@ spec:
                         x-kubernetes-list-map-keys:
                         - name
                         x-kubernetes-list-type: map
+                    type: object
+                  statefulSetMetadata:
+                    description: metadata for the Workspace StatefulSet (MUTABLE)
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: annotations to be applied to the Workspace StatefulSet
+                          resource
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: labels to be applied to the Workspace StatefulSet
+                          resource
+                        type: object
                     type: object
                   volumeMounts:
                     description: volume mount paths

--- a/applications/workspaces/upstream/controller/base/crd/kubeflow.org_workspaces.yaml
+++ b/applications/workspaces/upstream/controller/base/crd/kubeflow.org_workspaces.yaml
@@ -21,6 +21,18 @@ spec:
       jsonPath: .status.state
       name: State
       type: string
+    - description: The WorkspaceKind of the Workspace
+      jsonPath: .spec.kind
+      name: Kind
+      type: string
+    - description: The imageConfig option of the Workspace
+      jsonPath: .spec.podTemplate.options.imageConfig
+      name: Image Config
+      type: string
+    - description: The podConfig option of the Workspace
+      jsonPath: .spec.podTemplate.options.podConfig
+      name: Pod Config
+      type: string
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/applications/workspaces/upstream/controller/base/manager/kustomization.yaml
+++ b/applications/workspaces/upstream/controller/base/manager/kustomization.yaml
@@ -19,4 +19,4 @@ labels:
 images:
 - name: workspaces-controller
   newName: ghcr.io/kubeflow/notebooks/workspaces-controller
-  newTag: v2.0.0-beta.0
+  newTag: v2.0.0-beta.1

--- a/applications/workspaces/upstream/controller/samples/jupyterlab_v1beta1_workspacekind.yaml
+++ b/applications/workspaces/upstream/controller/samples/jupyterlab_v1beta1_workspacekind.yaml
@@ -151,6 +151,19 @@ spec:
       annotations:
         my-workspace-kind-annotation: "my-value"
 
+    ## metadata for the Workspace StatefulSet (MUTABLE)
+    ##  - labels and annotations applied to the StatefulSet object itself,
+    ##    unlike `podMetadata` which applies to the Workspace Pods
+    ##  - this is an admin-only default for all Workspaces of this WorkspaceKind
+    ##  - the controller-managed `notebooks.kubeflow.org/workspace-name` label
+    ##    always takes precedence and cannot be overridden here
+    ##
+    statefulSetMetadata:
+      labels:
+        my-workspace-kind-sts-label: "my-value"
+      annotations:
+        my-workspace-kind-sts-annotation: "my-value"
+
     ## service account configs for Workspace Pods
     ##  - each Workspace runs as its own ServiceAccount named "ws-{WORKSPACE_NAME}",
     ##    which the controller creates, owns, and deletes along with the Workspace
@@ -315,6 +328,15 @@ spec:
       runAsNonRoot: true
       seccompProfile:
         type: RuntimeDefault
+
+    ## the name of the scheduler to use for Workspace Pods (MUTABLE)
+    ##  - https://kubernetes.io/docs/tasks/extend-kubernetes/configure-multiple-schedulers/
+    ##  - this is the default for all Workspaces of this WorkspaceKind,
+    ##    it may be overridden by the `schedulerName` of a pod config value
+    ##  - if not set here, or on the pod config value, the Kubernetes API
+    ##    server will default to the "default-scheduler"
+    ##
+    #schedulerName: "default-scheduler"
 
     ## ==============================================================
     ## WORKSPACE OPTIONS
@@ -492,7 +514,7 @@ spec:
 
       ## ============================================================
       ## POD CONFIG OPTIONS
-      ##  - SETS: affinity, nodeSelector, tolerations, resources
+      ##  - SETS: affinity, nodeSelector, tolerations, resources, schedulerName
       ## ============================================================
       podConfig:
 
@@ -544,6 +566,14 @@ spec:
                 requests:
                   cpu: 100m
                   memory: 128Mi
+
+              ## the name of the scheduler to use for the pod
+              ##  - https://kubernetes.io/docs/tasks/extend-kubernetes/configure-multiple-schedulers/
+              ##  - this takes precedence over the `schedulerName` of the pod template
+              ##  - set this to "default-scheduler" to have this pod config use the
+              ##    default Kubernetes scheduler, even if the pod template sets another one
+              ##
+              #schedulerName: "default-scheduler"
 
           ## ================================================================
           ## EXAMPLE 2: a small CPU pod

--- a/applications/workspaces/upstream/frontend/base/kustomization.yaml
+++ b/applications/workspaces/upstream/frontend/base/kustomization.yaml
@@ -16,4 +16,4 @@ labels:
 images:
 - name: workspaces-frontend
   newName: ghcr.io/kubeflow/notebooks/workspaces-frontend
-  newTag: v2.0.0-beta.0
+  newTag: v2.0.0-beta.1

--- a/scripts/synchronize-kubeflow-workspaces-manifests.sh
+++ b/scripts/synchronize-kubeflow-workspaces-manifests.sh
@@ -6,7 +6,7 @@ setup_error_handling
 COMPONENT_NAME="workspaces"
 REPOSITORY_NAME="kubeflow/notebooks"
 REPOSITORY_URL="https://github.com/kubeflow/notebooks.git"
-COMMIT="v2.0.0-beta.0"
+COMMIT="v2.0.0-beta.1"
 REPOSITORY_DIRECTORY="$COMPONENT_NAME"
 SOURCE_DIRECTORY=${SOURCE_DIRECTORY:=/tmp/${COMPONENT_NAME}}
 BRANCH_NAME=${BRANCH_NAME:=synchronize-${COMPONENT_NAME}-manifests-${COMMIT?}}


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes

Update the Kubeflow Workspaces manifests to v2.0.0-beta.1

## 📦 Dependencies

_None_

## 🐛 Related Issues

_None_

## ✅ Contributor Checklist

- [x] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/community-distribution#prerequisites).
- [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
- [x] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).
