### PR TITLE
istio: namespace guard test, master push trigger, Helm 4 upgrade note

### DIFF
--- a/.github/workflows/helm-kustomize-comparison.yml
+++ b/.github/workflows/helm-kustomize-comparison.yml
@@ -1,6 +1,16 @@
 name: Helm vs Kustomize Comparison
 
 on:
+  push:
+    branches:
+    - master
+    paths:
+    - common/**
+    - applications/**
+    - experimental/**
+    - scripts/**
+    - tests/**
+    - .github/workflows/helm-kustomize-comparison.yml
   pull_request:
     paths:
     - common/**

--- a/common/istio/helm/README.md
+++ b/common/istio/helm/README.md
@@ -104,6 +104,28 @@ profile values files do not set it, so an upgrade that omits the flag resets
 the value to its `false` default and removes `Namespace/istio-system` from the
 release — deleting the namespace and everything inside it.
 
+## Upgrading
+
+Pass `--force-conflicts` on every `helm upgrade` of this release under Helm 4:
+
+```bash
+helm upgrade istio ./common/istio/helm \
+  --namespace istio-system \
+  --values ./common/istio/helm/ci/values-platform-full.yaml \
+  --force-conflicts \
+  --wait
+```
+
+Helm 4 applies server-side. Once istiod is ready, its validation controller
+(field manager `pilot-discovery`) sets `failurePolicy: Fail` on
+`ValidatingWebhookConfiguration/istio-validator-istio-system`; the payload
+ships `Ignore` so the webhook fails open until istiod answers. Without the
+flag the next upgrade stops with
+`conflict with "pilot-discovery" ... .webhooks[name="rev.validation.istio.io"].failurePolicy`.
+The flag reapplies the payload value and istiod sets `Fail` again within
+seconds. The Kustomize path never re-applies the webhook, so only Helm
+upgrades meet the conflict.
+
 ## Namespace names
 
 Namespace names are fixed to match the Kustomize baseline and `kubeflow-namespaces` foundation chart. Istio workloads use `istio-system`, Istio CNI resources use `kube-system`, and Kubeflow gateway resources refer to `kubeflow`. These names are not configurable.

--- a/tests/istio_helm_chart_test.py
+++ b/tests/istio_helm_chart_test.py
@@ -172,6 +172,30 @@ class IstioHelmChartTest(unittest.TestCase):
             result.stderr,
         )
 
+    def test_chart_refuses_a_foreign_namespace(self):
+        environment = os.environ.copy()
+        environment["HELM_PLUGINS"] = self.helm_plugins.name
+        result = subprocess.run(
+            [
+                HELM_BINARY,
+                "template",
+                "istio",
+                str(CHART_DIRECTORY),
+                "--namespace",
+                "not-istio-system",
+                "--values",
+                str(OAUTH2_PROXY_VALUES),
+            ],
+            capture_output=True,
+            text=True,
+            env=environment,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "must be installed into the istio-system namespace", result.stderr
+        )
+
     def test_readme_uses_canonical_synchronization_script_for_regeneration(self):
         readme = (CHART_DIRECTORY / "README.md").read_text()
         regeneration_section = readme.split("## Regenerate Static Manifests", 1)[


### PR DESCRIPTION
Follow-ups the approver asked for when merging the Istio namespace ownership and machine-to-machine gateway pull request ([#3567](https://github.com/kubeflow/community-distribution/pull/3567), "Please check the last review for follow ups"), plus one documentation finding from the first Helm-owned Istio run.

- `tests/istio_helm_chart_test.py`: `test_chart_refuses_a_foreign_namespace` renders the chart with `--namespace not-istio-system` and expects the guard to fail with its message, so weakening `templates/validate-namespace.yaml` cannot pass continuous integration ([review thread](https://github.com/kubeflow/community-distribution/pull/3567#discussion_r3950425393)).
- `.github/workflows/helm-kustomize-comparison.yml`: also runs on pushes to `master`, with the existing path filter, so the comparison and the chart behavior tests protect the merged branch ([review thread](https://github.com/kubeflow/community-distribution/pull/3567#discussion_r3950425335)).
- `common/istio/helm/README.md`: an "Upgrading" section. istiod's validation controller (field manager `pilot-discovery`) sets `failurePolicy: Fail` on `ValidatingWebhookConfiguration/istio-validator-istio-system` once the webhook is ready, while the payload ships `Ignore`; Helm 4 server-side apply therefore conflicts on every later `helm upgrade` unless `--force-conflicts` is passed. Observed on the Helm integration workflow ([job 102251723172](https://github.com/kubeflow/community-distribution/actions/runs/34282926805/job/102251723172)); the workflow pull request [#3595](https://github.com/kubeflow/community-distribution/pull/3595) passes the flag.

Verification: `python3 -m unittest tests.istio_helm_chart_test` (10 tests), `black --check`, `yamllint`, `git diff --check`.
